### PR TITLE
Implements "continuous" token balance delegation, updated tests, and airdrop example + test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cache/
 out/
 broadcast/
 Makefile
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/
 broadcast/
 Makefile
 .vscode
+remappings.txt

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
+[submodule "lib/murky"]
+	path = lib/murky
+	url = https://github.com/dmfxyz/murky

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,0 @@
-ds-test/=lib/forge-std/lib/ds-test/src/
-forge-std/=lib/forge-std/src/
-murky/=lib/murky/src/
-openzeppelin-contracts/=lib/openzeppelin-contracts/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,4 @@
+ds-test/=lib/forge-std/lib/ds-test/src/
+forge-std/=lib/forge-std/src/
+murky/=lib/murky/src/
+openzeppelin-contracts/=lib/openzeppelin-contracts/

--- a/src/IDelegationRegistry.sol
+++ b/src/IDelegationRegistry.sol
@@ -12,7 +12,9 @@ interface IDelegationRegistry {
         NONE,
         ALL,
         CONTRACT,
-        TOKEN
+        TOKEN,
+        BALANCE,
+        TOKEN_BALANCE
     }
     // ERC20,
     // ERC721,
@@ -25,6 +27,7 @@ interface IDelegationRegistry {
         address delegate;
         address contract_;
         uint256 tokenId;
+        uint256 balance;
         bytes32 data;
     }
 
@@ -36,6 +39,14 @@ interface IDelegationRegistry {
 
     /// @notice Emitted when a user delegates a specific token
     event DelegateForToken(address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, bool value, bytes32 data);
+
+    /// @notice Emitted when a user delegates a fungible balance
+    event DelegateForBalance(address indexed vault, address indexed delegate, address indexed contract_, uint256 balance, bool value, bytes32 data);
+
+    /// @notice Emitted when a user delegates a specific token with a specific balance
+    event DelegateForTokenBalance(
+        address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, uint256 balance, bool value, bytes32 data
+    );
 
     /**
      * -----------  WRITE -----------
@@ -71,6 +82,25 @@ interface IDelegationRegistry {
      * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
      */
     function delegateForToken(address delegate, address contract_, uint256 tokenId, bool value, bytes32 data) external;
+
+    /**
+     * @notice Allow the delegate to act on your behalf for a specific fungible balance
+     * @param delegate The hotwallet to act on your behalf
+     * @param contract_ The address for the fungible token contract
+     * @param balance The balance you want to delegate
+     * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+     */
+    function delegateForBalance(address delegate, address contract_, uint256 balance, bool value, bytes32 data) external;
+
+    /**
+     * @notice Allow the delegate to act on your behalf for a specific balance for a specific token
+     * @param delegate The hotwallet to act on your behalf
+     * @param contract_ The address of the contract that holds the token
+     * @param tokenId, the id of the token you are delegating the balance of
+     * @param balance The balance you want to delegate
+     * @param value Whether to enable or disable delegation for this address, true for setting and false for revoking
+     */
+    function delegateForTokenBalance(address delegate, address contract_, uint256 tokenId, uint256 balance, bool value, bytes32 data) external;
 
     /**
      * -----------  READ -----------
@@ -113,4 +143,23 @@ interface IDelegationRegistry {
      * @param vault The cold wallet who issued the delegation
      */
     function checkDelegateForToken(address delegate, address vault, address contract_, uint256 tokenId, bytes32 data) external view returns (bool);
+
+    /**
+     * @notice Returns the balance of a fungible token that the address is delegated to act on the behalf, or max(uint256) if the the token's contract or entire vault has been delegated (and 0 otherwise)
+     * @dev we may need to change this method or create another method since this isn't providing truth of a balance, just returning it
+     * @param delegate The hotwallet to act on your behalf
+     * @param contract_ The address of the token contract
+     * @param vault The cold wallet who issued the delegation
+     */
+    function checkDelegateForBalance(address delegate, address vault, address contract_, bytes32 data) external view returns (uint256);
+
+    /**
+     * @notice Returns the balance of a specific token that the address is delegated to act on the behalf, or max(uint256) if the the specific token, the token's contract or entire vault has been delegated (and 0 otherwise)
+     * @dev we may need to change this method or create another method since this isn't providing truth of a balance, just returning it
+     * @param delegate The hotwallet to act on your behalf
+     * @param contract_ The address of the token contract
+     * @param tokenId the token id for the token you're delegating the balance of
+     * @param vault The cold wallet who issued the delegation
+     */
+    function checkDelegateForTokenBalance(address delegate, address vault, address contract_, uint256 tokenId, bytes32 data) external view returns (uint256);
 }

--- a/src/examples/Airdrop.sol
+++ b/src/examples/Airdrop.sol
@@ -8,17 +8,17 @@ import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
 contract Airdrop is ERC20 {
-    Merkle m;
+    Merkle public m;
 
-    IDelegationRegistry r;
+    IDelegationRegistry public r;
 
     bytes32 public immutable merkleRoot;
 
     address public immutable referenceToken;
 
-    mapping(address claimant => uint256 claimed) claimed;
+    mapping(address claimant => uint256 claimed) public claimed;
 
-    mapping(address claimant => mapping(address beneficiary => uint256 claimed)) beneficiaryClaimed;
+    mapping(address claimant => mapping(address beneficiary => uint256 claimed)) public beneficiaryClaimed;
 
     error InvalidProof(bytes32 merkleRoot, bytes32[] merkleProof, bytes32 leaf);
 
@@ -26,11 +26,11 @@ contract Airdrop is ERC20 {
 
     event Claim(address indexed claimant, uint256 indexed amount, address beneficiary, uint256 received);
 
-    constructor(uint256 totalSupply_, bytes32 merkleRoot_, address referenceToken_, address registry) ERC20("Airdrop", "Air") {
+    constructor(address registry, uint256 totalSupply_, address referenceToken_, bytes32 merkleRoot_, address merkle) ERC20("Airdrop", "Air") {
         _mint(address(this), totalSupply_);
         merkleRoot = merkleRoot_;
         referenceToken = referenceToken_;
-        m = new Merkle();
+        m = Merkle(merkle);
         r = IDelegationRegistry(registry);
     }
 

--- a/src/examples/Airdrop.sol
+++ b/src/examples/Airdrop.sol
@@ -26,7 +26,7 @@ contract DelegateAirdrop is ERC20 {
 
     event DelegateClaim(address indexed vault, uint256 indexed airdropSize, address indexed delegate, uint256 delegateClaimed);
 
-    event Claim(address indexed claimant, uint256 indexed airdropSize);
+    event Claim(address indexed claimant, uint256 indexed airdropSize, uint256 claimable);
 
     constructor(address registry_, uint256 totalSupply_, address referenceToken_, bytes32 merkleRoot_, address merkle_) ERC20("Airdrop", "Air") {
         _mint(address(this), totalSupply_);
@@ -61,7 +61,7 @@ contract DelegateAirdrop is ERC20 {
             delegateClaimed[vault][msg.sender] += claimable;
             emit DelegateClaim(vault, airdropSize, msg.sender, claimable);
         } else {
-            emit Claim(vault, airdropSize);
+            emit Claim(vault, airdropSize, claimable);
         }
         // Increment claimed
         claimed[vault] += claimable;

--- a/src/examples/Airdrop.sol
+++ b/src/examples/Airdrop.sol
@@ -7,56 +7,65 @@ import {Merkle} from "murky/Merkle.sol";
 import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
-contract Airdrop is ERC20 {
-    Merkle public m;
+contract DelegateAirdrop is ERC20 {
+    Merkle public immutable merkle;
 
-    IDelegationRegistry public r;
+    IDelegationRegistry public immutable registry;
 
     bytes32 public immutable merkleRoot;
 
     address public immutable referenceToken;
 
-    mapping(address claimant => uint256 claimed) public claimed;
+    mapping(address vault => uint256 claimed) public claimed;
 
-    mapping(address claimant => mapping(address beneficiary => uint256 claimed)) public beneficiaryClaimed;
+    mapping(address vault => mapping(address delegate => uint256 claimed)) public delegateClaimed;
 
-    error InvalidProof(bytes32 merkleRoot, bytes32[] merkleProof, bytes32 leaf);
+    error InvalidProof(bytes32 merkleRoot, bytes32[] merkleProof, bytes32 merkleLeaf);
 
-    error InsufficientDelegation(uint256 delegationAmount, uint256 alreadyClaimed);
+    error InsufficientDelegation(uint256 delegationAmount, uint256 delegateClaimed);
 
-    event Claim(address indexed claimant, uint256 indexed amount, address beneficiary, uint256 received);
+    event DelegateClaim(address indexed vault, uint256 indexed airdropSize, address indexed delegate, uint256 delegateClaimed);
 
-    constructor(address registry, uint256 totalSupply_, address referenceToken_, bytes32 merkleRoot_, address merkle) ERC20("Airdrop", "Air") {
+    event Claim(address indexed claimant, uint256 indexed airdropSize);
+
+    constructor(address registry_, uint256 totalSupply_, address referenceToken_, bytes32 merkleRoot_, address merkle_) ERC20("Airdrop", "Air") {
         _mint(address(this), totalSupply_);
         merkleRoot = merkleRoot_;
         referenceToken = referenceToken_;
-        m = Merkle(merkle);
-        r = IDelegationRegistry(registry);
+        merkle = Merkle(merkle_);
+        registry = IDelegationRegistry(registry_);
     }
 
-    function claim(address claimant, uint256 amount, bytes32[] calldata merkleProof) external {
-        // First verify that airdrop for claimant for amount exists
-        if (!m.verifyProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(claimant, amount)))) {
-            revert InvalidProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(claimant, amount)));
+    function claim(address vault, uint256 airdropSize, bytes32[] calldata merkleProof) external {
+        // First verify that airdrop for vault of amount airdropSize exists
+        if (!merkle.verifyProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(vault, airdropSize)))) {
+            revert InvalidProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(vault, airdropSize)));
         }
-        // Now calculate remaining tokens that can be claimed
-        uint256 remainingTokens = amount - claimed[claimant];
-        // If msg.sender != claimant, check delegation instead
-        if (msg.sender != claimant) {
-            uint256 allowance = r.checkDelegateForBalance(msg.sender, claimant, referenceToken, "");
-            uint256 alreadyClaimed = beneficiaryClaimed[claimant][msg.sender];
-            if (alreadyClaimed >= allowance) {
-                revert InsufficientDelegation(allowance, alreadyClaimed);
+        // Now calculate remaining airdrop tokens that can be claimed by the vault
+        uint256 claimable = airdropSize - claimed[vault];
+        // If msg.sender != claimant, check balance delegation instead
+        if (msg.sender != vault) {
+            // Fetch the referenceToken balance delegated by the vault to msg.sender from the delegate registry
+            uint256 balance = registry.checkDelegateForBalance(msg.sender, vault, referenceToken, "");
+            // Load the amount tokens already claimed by msg.sender on behalf of the vault
+            uint256 alreadyClaimed = delegateClaimed[vault][msg.sender];
+            // Revert if msg.sender has already used up all the delegated balance
+            if (alreadyClaimed >= balance) {
+                revert InsufficientDelegation(balance, alreadyClaimed);
             }
-            uint256 remainingLimit = allowance - alreadyClaimed;
-            remainingTokens = Math.min(remainingTokens, remainingLimit);
-            // Decrement beneficiaryClaimed
-            beneficiaryClaimed[claimant][msg.sender] += remainingTokens;
+            // The maximum further tokens that can be claimed by msg.sender on behalf of vault
+            uint256 remainingLimit = balance - alreadyClaimed;
+            // Reduce claimable to remainingLimit if the limit is smaller
+            claimable = Math.min(claimable, remainingLimit);
+            // Increment beneficiaryClaimed by this amount
+            delegateClaimed[vault][msg.sender] += claimable;
+            emit DelegateClaim(vault, airdropSize, msg.sender, claimable);
+        } else {
+            emit Claim(vault, airdropSize);
         }
         // Increment claimed
-        claimed[claimant] += remainingTokens;
-        emit Claim(claimant, amount, msg.sender, remainingTokens);
-        // Transfer tokens
-        _transfer(address(this), msg.sender, remainingTokens);
+        claimed[vault] += claimable;
+        // Transfer tokens to msg.sender
+        _transfer(address(this), msg.sender, claimable);
     }
 }

--- a/src/examples/Airdrop.sol
+++ b/src/examples/Airdrop.sol
@@ -4,31 +4,50 @@ pragma solidity ^0.8.19;
 import {Merkle} from "murky/Merkle.sol";
 import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
-import {DelegateAirdrop} from "src/examples/DelegateAirdrop.sol";
+import {DelegateClaim} from "src/examples/DelegateClaim.sol";
 
-contract Airdrop is ERC20, DelegateAirdrop {
+/**
+ * @title Airdrop
+ * @notice A contract for distributing tokens through a merkle tree-based airdrop mechanism.
+ * @dev Inherits the DelegateClaim contract to allow delegates to claim on behalf of vaults.
+ */
+contract Airdrop is ERC20, DelegateClaim {
     Merkle public immutable merkle;
-
     bytes32 public immutable merkleRoot;
-
     mapping(address vault => uint256 claimed) public claimed;
 
+    /**
+     * @notice Initializes the Airdrop contract.
+     * @param registry_ The address of the v2 delegation registry contract.
+     * @param referenceToken_ The address of the reference token used by delegateClaimable inherited from DelegateClaim.
+     * @param totalSupply_ The total supply of the airdrop token.
+     * @param merkleRoot_ The root hash of the merkle tree representing the airdrop.
+     * @param merkle_ The address of the murky Merkle contract used for proof verification.
+     */
     constructor(address registry_, address referenceToken_, uint256 totalSupply_, bytes32 merkleRoot_, address merkle_)
         ERC20("Airdrop", "Air")
-        DelegateAirdrop(registry_, referenceToken_)
+        DelegateClaim(registry_, referenceToken_)
     {
         _mint(address(this), totalSupply_);
         merkleRoot = merkleRoot_;
         merkle = Merkle(merkle_);
     }
 
-    function claim(uint256 claimAmount, address vault, uint256 airdropSize, bytes32[] calldata merkleProof) external {
+    /**
+     * @notice Allows the caller to claim tokens from the airdrop based on the merkle proof, and if they aren't the vault,
+     * claim tokens on behalf of vault if they have a delegation.
+     * @param vault The address of the vault.
+     * @param claimAmount The amount of tokens to claim from the airdrop.
+     * @param airdropSize The total size of the airdrop for the vault.
+     * @param merkleProof The merkle proof to verify the airdrop allocation for vault of airdropSize.
+     */
+    function claim(address vault, uint256 claimAmount, uint256 airdropSize, bytes32[] calldata merkleProof) external {
         // First verify that airdrop for vault of amount airdropSize exists
         require(merkle.verifyProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(vault, airdropSize))), "Invalid Proof");
         // Set claimable to the minimum of claimAmount and the maximum remaining airdrop tokens that can be claimed by the vault
         uint256 claimable = Math.min(claimAmount, airdropSize - claimed[vault]);
         // If msg.sender != vault, check balance delegation instead
-        if (msg.sender != vault) claimable = delegateClaimable(vault, claimable);
+        if (msg.sender != vault) claimable = _delegateClaimable(vault, claimable);
         // Increment claimed
         claimed[vault] += claimable;
         // Transfer tokens to msg.sender

--- a/src/examples/Airdrop.sol
+++ b/src/examples/Airdrop.sol
@@ -51,7 +51,7 @@ contract Airdrop is ERC20 {
             uint256 remainingLimit = allowance - alreadyClaimed;
             remainingTokens = Math.min(remainingTokens, remainingLimit);
             // Decrement beneficiaryClaimed
-            beneficiaryClaimed[claimant][msg.sender] -= remainingTokens;
+            beneficiaryClaimed[claimant][msg.sender] += remainingTokens;
         }
         // Increment claimed
         claimed[claimant] += remainingTokens;

--- a/src/examples/Airdrop.sol
+++ b/src/examples/Airdrop.sol
@@ -22,7 +22,7 @@ contract Airdrop is ERC20 {
 
     error InvalidProof(bytes32 merkleRoot, bytes32[] merkleProof, bytes32 leaf);
 
-    error InsufficientDelegation(delegationAmount, alreadyClaimed);
+    error InsufficientDelegation(uint256 delegationAmount, uint256 alreadyClaimed);
 
     event Claim(address indexed claimant, uint256 indexed amount, address beneficiary, uint256 received);
 
@@ -45,8 +45,8 @@ contract Airdrop is ERC20 {
         if (msg.sender != claimant) {
             uint256 allowance = r.checkDelegateForBalance(msg.sender, claimant, referenceToken, "");
             uint256 alreadyClaimed = beneficiaryClaimed[claimant][msg.sender];
-            if (beneficiaryClaimed >= alreadyClaimed) {
-                revert InsufficientDelegation(delegationAmount, alreadyClaimed);
+            if (alreadyClaimed >= allowance) {
+                revert InsufficientDelegation(allowance, alreadyClaimed);
             }
             uint256 remainingLimit = allowance - alreadyClaimed;
             remainingTokens = Math.min(remainingTokens, remainingLimit);

--- a/src/examples/Airdrop.sol
+++ b/src/examples/Airdrop.sol
@@ -1,68 +1,34 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.19;
 
-import {IDelegationRegistry} from "../IDelegationRegistry.sol";
-
 import {Merkle} from "murky/Merkle.sol";
 import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import {DelegateAirdrop} from "src/examples/DelegateAirdrop.sol";
 
-contract DelegateAirdrop is ERC20 {
+contract Airdrop is ERC20, DelegateAirdrop {
     Merkle public immutable merkle;
-
-    IDelegationRegistry public immutable registry;
 
     bytes32 public immutable merkleRoot;
 
-    address public immutable referenceToken;
-
     mapping(address vault => uint256 claimed) public claimed;
 
-    mapping(address vault => mapping(address delegate => uint256 claimed)) public delegateClaimed;
-
-    error InvalidProof(bytes32 merkleRoot, bytes32[] merkleProof, bytes32 merkleLeaf);
-
-    error InsufficientDelegation(uint256 delegationAmount, uint256 delegateClaimed);
-
-    event DelegateClaim(address indexed vault, uint256 indexed airdropSize, address indexed delegate, uint256 delegateClaimed);
-
-    event Claim(address indexed claimant, uint256 indexed airdropSize, uint256 claimable);
-
-    constructor(address registry_, uint256 totalSupply_, address referenceToken_, bytes32 merkleRoot_, address merkle_) ERC20("Airdrop", "Air") {
+    constructor(address registry_, address referenceToken_, uint256 totalSupply_, bytes32 merkleRoot_, address merkle_)
+        ERC20("Airdrop", "Air")
+        DelegateAirdrop(registry_, referenceToken_)
+    {
         _mint(address(this), totalSupply_);
         merkleRoot = merkleRoot_;
-        referenceToken = referenceToken_;
         merkle = Merkle(merkle_);
-        registry = IDelegationRegistry(registry_);
     }
 
     function claim(uint256 claimAmount, address vault, uint256 airdropSize, bytes32[] calldata merkleProof) external {
         // First verify that airdrop for vault of amount airdropSize exists
-        if (!merkle.verifyProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(vault, airdropSize)))) {
-            revert InvalidProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(vault, airdropSize)));
-        }
+        require(merkle.verifyProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(vault, airdropSize))), "Invalid Proof");
         // Set claimable to the minimum of claimAmount and the maximum remaining airdrop tokens that can be claimed by the vault
         uint256 claimable = Math.min(claimAmount, airdropSize - claimed[vault]);
         // If msg.sender != vault, check balance delegation instead
-        if (msg.sender != vault) {
-            // Fetch the referenceToken balance delegated by the vault to msg.sender from the delegate registry
-            uint256 balance = registry.checkDelegateForBalance(msg.sender, vault, referenceToken, "");
-            // Load the amount tokens already claimed by msg.sender on behalf of the vault
-            uint256 alreadyClaimed = delegateClaimed[vault][msg.sender];
-            // Revert if msg.sender has already used up all the delegated balance
-            if (alreadyClaimed >= balance) {
-                revert InsufficientDelegation(balance, alreadyClaimed);
-            }
-            // Calculate maximum further tokens that can be claimed by msg.sender on behalf of vault
-            uint256 remainingLimit = balance - alreadyClaimed;
-            // Reduce claimable to remainingLimit if the limit is smaller
-            claimable = Math.min(claimable, remainingLimit);
-            // Increment beneficiaryClaimed by this amount
-            delegateClaimed[vault][msg.sender] += claimable;
-            emit DelegateClaim(vault, airdropSize, msg.sender, claimable);
-        } else {
-            emit Claim(vault, airdropSize, claimable);
-        }
+        if (msg.sender != vault) claimable = delegateClaimable(vault, claimable);
         // Increment claimed
         claimed[vault] += claimable;
         // Transfer tokens to msg.sender

--- a/src/examples/Airdrop.sol
+++ b/src/examples/Airdrop.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.19;
+
+import {IDelegationRegistry} from "../IDelegationRegistry.sol";
+
+import {Merkle} from "murky/Merkle.sol";
+import {ERC20} from "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+
+contract Airdrop is ERC20 {
+    Merkle m;
+
+    IDelegationRegistry r;
+
+    bytes32 public immutable merkleRoot;
+
+    address public immutable referenceToken;
+
+    mapping(address claimant => uint256 claimed) claimed;
+
+    mapping(address claimant => mapping(address beneficiary => uint256 claimed)) beneficiaryClaimed;
+
+    error InvalidProof(bytes32 merkleRoot, bytes32[] merkleProof, bytes32 leaf);
+
+    error InsufficientDelegation(delegationAmount, alreadyClaimed);
+
+    event Claim(address indexed claimant, uint256 indexed amount, address beneficiary, uint256 received);
+
+    constructor(uint256 totalSupply_, bytes32 merkleRoot_, address referenceToken_, address registry) ERC20("Airdrop", "Air") {
+        _mint(address(this), totalSupply_);
+        merkleRoot = merkleRoot_;
+        referenceToken = referenceToken_;
+        m = new Merkle();
+        r = IDelegationRegistry(registry);
+    }
+
+    function claim(address claimant, uint256 amount, bytes32[] calldata merkleProof) external {
+        // First verify that airdrop for claimant for amount exists
+        if (!m.verifyProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(claimant, amount)))) {
+            revert InvalidProof(merkleRoot, merkleProof, keccak256(abi.encodePacked(claimant, amount)));
+        }
+        // Now calculate remaining tokens that can be claimed
+        uint256 remainingTokens = amount - claimed[claimant];
+        // If msg.sender != claimant, check delegation instead
+        if (msg.sender != claimant) {
+            uint256 allowance = r.checkDelegateForBalance(msg.sender, claimant, referenceToken, "");
+            uint256 alreadyClaimed = beneficiaryClaimed[claimant][msg.sender];
+            if (beneficiaryClaimed >= alreadyClaimed) {
+                revert InsufficientDelegation(delegationAmount, alreadyClaimed);
+            }
+            uint256 remainingLimit = allowance - alreadyClaimed;
+            remainingTokens = Math.min(remainingTokens, remainingLimit);
+            // Decrement beneficiaryClaimed
+            beneficiaryClaimed[claimant][msg.sender] -= remainingTokens;
+        }
+        // Increment claimed
+        claimed[claimant] += remainingTokens;
+        emit Claim(claimant, amount, msg.sender, remainingTokens);
+        // Transfer tokens
+        _transfer(address(this), msg.sender, remainingTokens);
+    }
+}

--- a/src/examples/DelegateAirdrop.sol
+++ b/src/examples/DelegateAirdrop.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.19;
+
+import {IDelegationRegistry} from "src/IDelegationRegistry.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+
+contract DelegateAirdrop {
+    IDelegationRegistry public immutable delegateRegistry;
+
+    address public immutable referenceToken;
+
+    mapping(address vault => mapping(address delegate => uint256 claimed)) public delegateClaimed;
+
+    constructor(address registry_, address referenceToken_) {
+        delegateRegistry = IDelegationRegistry(registry_);
+        referenceToken = referenceToken_;
+    }
+
+    function delegateClaimable(address vault, uint256 claimable) internal returns (uint256) {
+        // Fetch the referenceToken balance delegated by the vault to msg.sender from the delegate registry
+        uint256 balance = delegateRegistry.checkDelegateForBalance(msg.sender, vault, referenceToken, "");
+        // Load the amount tokens already claimed by msg.sender on behalf of the vault
+        uint256 alreadyClaimed = delegateClaimed[vault][msg.sender];
+        // Revert if msg.sender has already used up all the delegated balance
+        require(balance > alreadyClaimed, "Insufficient Delegation");
+        // Calculate maximum further tokens that can be claimed by msg.sender on behalf of vault
+        uint256 remainingLimit = balance - alreadyClaimed;
+        // Reduce claimable to remainingLimit if the limit is smaller
+        claimable = Math.min(claimable, remainingLimit);
+        // Increment beneficiaryClaimed by this amount
+        delegateClaimed[vault][msg.sender] += claimable;
+        return claimable;
+    }
+}

--- a/src/examples/DelegateClaim.sol
+++ b/src/examples/DelegateClaim.sol
@@ -4,19 +4,34 @@ pragma solidity ^0.8.19;
 import {IDelegationRegistry} from "src/IDelegationRegistry.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
-contract DelegateAirdrop {
+/**
+ * @title DelegateClaim
+ * @dev A contract for claiming tokens on behalf of a vault using the v2 delegation registry.
+ */
+contract DelegateClaim {
     IDelegationRegistry public immutable delegateRegistry;
-
     address public immutable referenceToken;
-
+    /**
+     * @dev stores accounting for the tokens claimed by a delegate on behalf of a vault.
+     */
     mapping(address vault => mapping(address delegate => uint256 claimed)) public delegateClaimed;
 
+    /**
+     * @param registry_ The address of the v2 delegation registry contract.
+     * @param referenceToken_ The address of the reference token.
+     */
     constructor(address registry_, address referenceToken_) {
         delegateRegistry = IDelegationRegistry(registry_);
         referenceToken = referenceToken_;
     }
 
-    function delegateClaimable(address vault, uint256 claimable) internal returns (uint256) {
+    /**
+     * @dev Calculates the claimable tokens for a specific vault and claimable amount.
+     * @param vault The address of the vault.
+     * @param claimable The amount of tokens that can be claimed by vault.
+     * @return The actual amount of tokens that can be claimed by the caller on behalf of vault.
+     */
+    function _delegateClaimable(address vault, uint256 claimable) internal returns (uint256) {
         // Fetch the referenceToken balance delegated by the vault to msg.sender from the delegate registry
         uint256 balance = delegateRegistry.checkDelegateForBalance(msg.sender, vault, referenceToken, "");
         // Load the amount tokens already claimed by msg.sender on behalf of the vault

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -24,27 +24,31 @@ contract DelegationRegistryTest is Test {
         emit log_bytes32(initHash);
     }
 
-    function testApproveAndRevokeForAll(address vault, address delegate) public {
+    function testApproveAndRevokeForAll(address vault, address delegate, address contract_, uint256 tokenId, bytes32 data_) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForAll(delegate, true, data);
-        assertTrue(reg.checkDelegateForAll(delegate, vault, data));
-        assertTrue(reg.checkDelegateForContract(delegate, vault, address(0x0), data));
-        assertTrue(reg.checkDelegateForToken(delegate, vault, address(0x0), 0, data));
+        reg.delegateForAll(delegate, true, data_);
+        assertTrue(reg.checkDelegateForAll(delegate, vault, data_));
+        assertTrue(reg.checkDelegateForContract(delegate, vault, contract_, data_));
+        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, tokenId, data_));
+        assertEq(reg.checkDelegateForBalance(delegate, vault, contract_, data_), type(uint256).max);
+        assertEq(reg.checkDelegateForTokenBalance(delegate, vault, contract_, 0, data_), type(uint256).max);
         // Revoke
-        reg.delegateForAll(delegate, false, data);
-        assertFalse(reg.checkDelegateForAll(delegate, vault, data));
+        reg.delegateForAll(delegate, false, data_);
+        assertFalse(reg.checkDelegateForAll(delegate, vault, data_));
     }
 
-    function testApproveAndRevokeForContract(address vault, address delegate, address contract_) public {
+    function testApproveAndRevokeForContract(address vault, address delegate, address contract_, uint256 tokenId, bytes32 data_) public {
         // Approve
         vm.startPrank(vault);
-        reg.delegateForContract(delegate, contract_, true, data);
-        assertTrue(reg.checkDelegateForContract(delegate, vault, contract_, data));
-        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, 0, data));
+        reg.delegateForContract(delegate, contract_, true, data_);
+        assertTrue(reg.checkDelegateForContract(delegate, vault, contract_, data_));
+        assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, tokenId, data_));
+        assertEq(reg.checkDelegateForBalance(delegate, vault, contract_, data_), type(uint256).max);
+        assertEq(reg.checkDelegateForTokenBalance(delegate, vault, contract_, tokenId, data_), type(uint256).max);
         // Revoke
-        reg.delegateForContract(delegate, contract_, false, data);
-        assertFalse(reg.checkDelegateForContract(delegate, vault, contract_, data));
+        reg.delegateForContract(delegate, contract_, false, data_);
+        assertFalse(reg.checkDelegateForContract(delegate, vault, contract_, data_));
     }
 
     function testApproveAndRevokeForToken(address vault, address delegate, address contract_, uint256 tokenId) public {
@@ -52,9 +56,30 @@ contract DelegationRegistryTest is Test {
         vm.startPrank(vault);
         reg.delegateForToken(delegate, contract_, tokenId, true, data);
         assertTrue(reg.checkDelegateForToken(delegate, vault, contract_, tokenId, data));
+        assertEq(reg.checkDelegateForTokenBalance(delegate, vault, contract_, tokenId, data), type(uint256).max);
         // Revoke
         reg.delegateForToken(delegate, contract_, tokenId, false, data);
         assertFalse(reg.checkDelegateForToken(delegate, vault, contract_, tokenId, data));
+    }
+
+    function testApproveAndRevokeForBalance(address vault, address delegate, address contract_, uint256 balance, bytes32 data_) public {
+        // Approve
+        vm.startPrank(vault);
+        reg.delegateForBalance(delegate, contract_, balance, true, data_);
+        assertEq(reg.checkDelegateForBalance(delegate, vault, contract_, data_), balance);
+        // Revoke
+        reg.delegateForBalance(delegate, contract_, balance, false, data_);
+        assertEq(reg.checkDelegateForBalance(delegate, vault, contract_, data_), 0);
+    }
+
+    function testApproveAndRevokeForTokenBalance(address vault, address delegate, address contract_, uint256 tokenId, uint256 balance, bytes32 data_) public {
+        // Approve
+        vm.startPrank(vault);
+        reg.delegateForTokenBalance(delegate, contract_, tokenId, balance, true, data_);
+        assertEq(reg.checkDelegateForTokenBalance(delegate, vault, contract_, tokenId, data_), balance);
+        // Revoke
+        reg.delegateForTokenBalance(delegate, contract_, tokenId, balance, false, data_);
+        assertEq(reg.checkDelegateForTokenBalance(delegate, vault, contract_, tokenId, data_), 0);
     }
 
     function testMultipleDelegationForAll(address vault, address delegate0, address delegate1) public {
@@ -85,6 +110,7 @@ contract DelegationRegistryTest is Test {
             delegate: delegate0,
             contract_: address(0),
             tokenId: 0,
+            balance: 0,
             data: data
         });
         info[1] = IDelegationRegistry.DelegationInfo({
@@ -93,6 +119,7 @@ contract DelegationRegistryTest is Test {
             delegate: delegate1,
             contract_: address(0),
             tokenId: 0,
+            balance: 0,
             data: data
         });
         bool[] memory values = new bool[](2);
@@ -118,72 +145,82 @@ contract DelegationRegistryTest is Test {
         address contract0,
         address contract1,
         uint256 tokenId0,
-        uint256 tokenId1
+        uint256 tokenId1,
+        uint256 balance0,
+        uint256 balance1
     ) public {
-        vm.assume(vault0 != vault1);
-        vm.assume(vault0 != delegate0);
-        vm.assume(vault0 != delegate1);
-        vm.assume(vault1 != delegate0);
-        vm.assume(vault1 != delegate1);
+        vm.assume(vault0 != vault1 && vault0 != delegate0 && vault0 != delegate1);
+        vm.assume(vault1 != delegate0 && vault1 != delegate1);
         vm.assume(delegate0 != delegate1);
-        vm.assume(contract0 != contract1);
-        vm.assume(tokenId0 != tokenId1);
-        vm.assume(contract0 != address(0x0));
-        vm.assume(contract1 != address(0x0));
-        vm.assume(tokenId0 != 0);
-        vm.assume(tokenId1 != 0);
+        vm.assume(contract0 != address(0) && contract1 != address(0) && contract0 != contract1);
+        vm.assume(tokenId0 != 0 && tokenId1 != 0 && tokenId0 != tokenId1);
+        vm.assume(balance0 != 0 && balance1 != 0 && balance0 != balance1);
 
-        // vault0 delegates all three tiers to delegate0, and all three tiers to delegate1
+        // vault0 delegates all five tiers to delegate0, and all five giv to delegate1
         vm.startPrank(vault0);
         reg.delegateForAll(delegate0, true, data);
         reg.delegateForContract(delegate0, contract0, true, data);
         reg.delegateForToken(delegate0, contract0, tokenId0, true, data);
+        reg.delegateForBalance(delegate0, contract0, balance0, true, data);
+        reg.delegateForTokenBalance(delegate0, contract0, tokenId0, balance0, true, data);
         reg.delegateForAll(delegate1, true, data);
         reg.delegateForContract(delegate1, contract1, true, data);
         reg.delegateForToken(delegate1, contract1, tokenId1, true, data);
+        reg.delegateForBalance(delegate1, contract1, balance1, true, data);
+        reg.delegateForTokenBalance(delegate1, contract1, tokenId1, balance1, true, data);
 
-        // vault1 delegates all three tiers to delegate0
+        // vault1 delegates all five tiers to delegate0
         changePrank(vault1);
         reg.delegateForAll(delegate0, true, data);
         reg.delegateForContract(delegate0, contract0, true, data);
         reg.delegateForToken(delegate0, contract0, tokenId0, true, data);
+        reg.delegateForBalance(delegate0, contract0, balance0, true, data);
+        reg.delegateForTokenBalance(delegate0, contract0, tokenId0, balance0, true, data);
 
         // vault0 revokes all three tiers for delegate0, check incremental decrease in delegate enumerations
         changePrank(vault0);
         // check six in total, three from vault0 and three from vault1
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 6);
+        assertEq(reg.getDelegationsForDelegate(delegate0).length, 10);
         reg.delegateForAll(delegate0, false, data);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 5);
+        assertEq(reg.getDelegationsForDelegate(delegate0).length, 9);
         reg.delegateForContract(delegate0, contract0, false, data);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 4);
+        assertEq(reg.getDelegationsForDelegate(delegate0).length, 8);
         reg.delegateForToken(delegate0, contract0, tokenId0, false, data);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 3);
+        assertEq(reg.getDelegationsForDelegate(delegate0).length, 7);
+        reg.delegateForBalance(delegate0, contract0, balance0, false, data);
+        assertEq(reg.getDelegationsForDelegate(delegate0).length, 6);
+        reg.delegateForTokenBalance(delegate0, contract0, tokenId0, balance0, false, data);
+        assertEq(reg.getDelegationsForDelegate(delegate0).length, 5);
 
         // vault0 re-delegates to delegate0
         changePrank(vault0);
         reg.delegateForAll(delegate0, true, data);
         reg.delegateForContract(delegate0, contract0, true, data);
         reg.delegateForToken(delegate0, contract0, tokenId0, true, data);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 6);
-        assertEq(reg.getDelegationsForDelegate(delegate1).length, 3);
+        reg.delegateForBalance(delegate0, contract0, balance0, true, data);
+        reg.delegateForTokenBalance(delegate0, contract0, tokenId0, balance0, true, data);
+        assertEq(reg.getDelegationsForDelegate(delegate0).length, 10);
+        assertEq(reg.getDelegationsForDelegate(delegate1).length, 5);
     }
 
-    function testVaultEnumerations(address vault, address delegate0, address delegate1, address contract0, address contract1, uint256 tokenId) public {
-        vm.assume(vault != delegate0);
-        vm.assume(vault != delegate1);
+    function testVaultEnumerations(address vault, address delegate0, address delegate1, address contract0, address contract1, uint256 tokenId, uint256 balance)
+        public
+    {
+        vm.assume(vault != delegate0 && vault != delegate1);
         vm.assume(delegate0 != delegate1);
         vm.assume(contract0 != contract1);
         vm.startPrank(vault);
         reg.delegateForAll(delegate0, true, data);
         reg.delegateForContract(delegate0, contract0, true, data);
         reg.delegateForToken(delegate0, contract1, tokenId, true, data);
+        reg.delegateForBalance(delegate0, contract1, balance, true, data);
         reg.delegateForAll(delegate1, true, data);
         reg.delegateForContract(delegate1, contract0, true, data);
 
         // Read
         IDelegationRegistry.DelegationInfo[] memory vaultDelegations;
         vaultDelegations = reg.getDelegationsForVault(vault);
-        assertEq(vaultDelegations.length, 5);
+        assertEq(vaultDelegations.length, 6);
         assertTrue(vaultDelegations[1].type_ == IDelegationRegistry.DelegationType.CONTRACT);
     }
 }

--- a/test/examples/Airdrop.t.sol
+++ b/test/examples/Airdrop.t.sol
@@ -5,7 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {console2} from "forge-std/console2.sol";
 
 import {Merkle} from "murky/Merkle.sol";
-import {Airdrop} from "../../src/examples/Airdrop.sol";
+import {Airdrop} from "src/examples/Airdrop.sol";
 import {DelegationRegistry} from "src/DelegationRegistry.sol";
 import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 

--- a/test/examples/Airdrop.t.sol
+++ b/test/examples/Airdrop.t.sol
@@ -7,35 +7,45 @@ import {console2} from "forge-std/console2.sol";
 import {Merkle} from "murky/Merkle.sol";
 import {Airdrop} from "../../src/examples/Airdrop.sol";
 import {DelegationRegistry} from "src/DelegationRegistry.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
 
 contract AirdropTest is Test {
-    Merkle m;
+    Merkle public m;
 
-    DelegationRegistry r;
+    DelegationRegistry public r;
 
     struct AirdropRecord {
         address receiver;
         uint256 amount;
     }
 
-    uint256 constant maxAirdropSize = 100;
+    uint256 public constant MAX_AIRDROP_SIZE = 100;
 
-    Airdrop a;
+    uint256 public constant MAX_AMOUNT = 2 ** 200;
 
-    AirdropRecord[] airdrop;
+    Airdrop public a;
 
-    bytes32[] airdropData;
+    AirdropRecord[] public airdrop;
 
-    bytes32 root;
+    bytes32[] public airdropData;
+
+    bytes32 public root;
+
+    struct Delegate {
+        address delegate;
+        uint256 allowance;
+    }
+
+    Delegate[] public delegates;
 
     function setUp() public {
         m = new Merkle();
         r = new DelegationRegistry();
     }
 
-    function createAirdrop(uint256 addressSeed, uint256 amountSeed, uint256 n) internal {
+    function _createAirdrop(uint256 addressSeed, uint256 amountSeed, uint256 n) internal {
         for (uint256 i = 0; i < n; i++) {
-            (,, bytes32 data, AirdropRecord memory record) = generateAirdropRecord(addressSeed, amountSeed, i);
+            (,, bytes32 data, AirdropRecord memory record) = _generateAirdropRecord(addressSeed, amountSeed, i);
             // Append to list
             airdropData.push(data);
             // Add to airdrop mapping
@@ -44,23 +54,24 @@ contract AirdropTest is Test {
         root = m.getRoot(airdropData);
     }
 
-    function generateAirdropRecord(uint256 addressSeed, uint256 amountSeed, uint256 i)
+    function _generateAirdropRecord(uint256 addressSeed, uint256 amountSeed, uint256 i)
         internal
         pure
         returns (uint256 amount, address receiver, bytes32 data, AirdropRecord memory record)
     {
-        amount = 1 + (uint256(keccak256(abi.encode(amountSeed, i))) % 2 ** 200);
+        amount = (uint256(keccak256(abi.encode(amountSeed, i))) % MAX_AMOUNT);
+        if (amount == 0) amount += 1;
         receiver = address(bytes20(keccak256(abi.encode(addressSeed, i))));
         data = keccak256(abi.encodePacked(receiver, amount));
         record = AirdropRecord({receiver: receiver, amount: amount});
     }
 
     function testCreateAirdrop(uint256 addressSeed, uint256 amountSeed, uint256 n, uint256 x) public {
-        vm.assume(n > 1 && n < maxAirdropSize);
-        createAirdrop(addressSeed, amountSeed, n);
+        vm.assume(n > 1 && n < MAX_AIRDROP_SIZE);
+        _createAirdrop(addressSeed, amountSeed, n);
         // Test random value
         vm.assume(x < n);
-        (uint256 amount, address receiver,,) = generateAirdropRecord(addressSeed, amountSeed, x);
+        (uint256 amount, address receiver,,) = _generateAirdropRecord(addressSeed, amountSeed, x);
         // Load struct and data from storage
         AirdropRecord memory record = airdrop[x];
         bytes32 data = keccak256(abi.encodePacked(receiver, amount));
@@ -73,8 +84,8 @@ contract AirdropTest is Test {
     }
 
     function testAirdropWithoutDelegate(uint256 addressSeed, uint256 amountSeed, uint256 n, address referenceToken) public {
-        vm.assume(n > 1 && n < maxAirdropSize && addressSeed != amountSeed);
-        createAirdrop(addressSeed, amountSeed, n);
+        vm.assume(n > 1 && n < MAX_AIRDROP_SIZE && addressSeed != amountSeed);
+        _createAirdrop(addressSeed, amountSeed, n);
         // Calculate total tokens to mint
         uint256 totalSupply_;
         for (uint256 i; i < n; i++) {
@@ -91,7 +102,7 @@ contract AirdropTest is Test {
         assertEq(totalSupply_, a.balanceOf(address(a)));
         // Try to claim with bogus proof
         for (uint256 i = 0; i < n; i++) {
-            (uint256 bogusAmount, address bogusReceiver, bytes32 bogusData,) = generateAirdropRecord(amountSeed, addressSeed, i);
+            (uint256 bogusAmount, address bogusReceiver, bytes32 bogusData,) = _generateAirdropRecord(amountSeed, addressSeed, i);
             bytes32[] memory proof = m.getProof(airdropData, i);
             vm.startPrank(bogusReceiver);
             vm.expectRevert(abi.encodeWithSelector(Airdrop.InvalidProof.selector, root, proof, bogusData));
@@ -115,5 +126,84 @@ contract AirdropTest is Test {
         }
         // Verify that contract no longer has any tokens
         assertEq(0, a.balanceOf(address(a)));
+    }
+
+    function _createDelegates(uint256 delegateSeed, uint256 allowanceSeed, uint256 n) internal {
+        for (uint256 i = 0; i < n; i++) {
+            uint256 allowance = uint256(keccak256(abi.encode(allowanceSeed, i))) % MAX_AMOUNT;
+            if (allowance == 0) allowance += 1;
+            address delegate = address(bytes20(keccak256(abi.encode(delegateSeed, i))));
+            delegates.push(Delegate({delegate: delegate, allowance: allowance}));
+        }
+    }
+
+    function testAirdropWithDelegateBalance(
+        uint256 addressSeed,
+        uint256 amountSeed,
+        uint256 n,
+        address referenceToken,
+        uint256 delegateSeed,
+        uint256 allowanceSeed
+    ) public {
+        vm.assume(n > 1 && n < MAX_AIRDROP_SIZE && addressSeed != amountSeed && addressSeed != delegateSeed && addressSeed != allowanceSeed);
+        vm.assume(amountSeed != delegateSeed && amountSeed != allowanceSeed);
+        vm.assume(delegateSeed != allowanceSeed);
+        _createAirdrop(addressSeed, amountSeed, n);
+        // Calculate total tokens to mint
+        uint256 totalSupply_;
+        for (uint256 i; i < n; i++) {
+            totalSupply_ += airdrop[i].amount;
+        }
+        // Create airdrop token
+        a = new Airdrop(address(r), totalSupply_, referenceToken, root, address(m));
+        // Create delegates
+        _createDelegates(delegateSeed, allowanceSeed, n);
+        // Try to claim with delegate
+        // Try to claim every airdrop with delegate
+        for (uint256 i = 0; i < n; i++) {
+            address claimant = airdrop[i].receiver;
+            uint256 amount = airdrop[i].amount;
+            bytes32[] memory proof = m.getProof(airdropData, i);
+            vm.startPrank(delegates[i].delegate);
+            vm.expectRevert(abi.encodeWithSelector(Airdrop.InsufficientDelegation.selector, 0, 0));
+            a.claim(claimant, amount, proof);
+            vm.stopPrank();
+        }
+        // Delegate and claim airdrop
+        for (uint256 i = 0; i < n; i++) {
+            // Delegate
+            vm.startPrank(airdrop[i].receiver);
+            r.delegateForBalance(delegates[i].delegate, referenceToken, delegates[i].allowance, true, "");
+            vm.stopPrank();
+            // Delegate claims airdrop
+            vm.startPrank(delegates[i].delegate);
+            bytes32[] memory proof = m.getProof(airdropData, i);
+            a.claim(airdrop[i].receiver, airdrop[i].amount, proof);
+            vm.stopPrank();
+            uint256 claimed = Math.min(delegates[i].allowance, airdrop[i].amount);
+            // Check that claimed is as expected
+            assertEq(claimed, a.claimed(airdrop[i].receiver));
+            // Check that beneficiary claimed is as expected
+            assertEq(claimed, a.beneficiaryClaimed(airdrop[i].receiver, delegates[i].delegate));
+            // Expect that token balance is claimed
+            assertEq(claimed, a.balanceOf(delegates[i].delegate));
+            // If claimed is airdrop amount, delegate tries to claim again but they receive no further tokens
+            if (claimed == airdrop[i].amount) {
+                vm.startPrank(delegates[i].delegate);
+                a.claim(airdrop[i].receiver, airdrop[i].amount, proof);
+                vm.stopPrank();
+            }
+            // Otherwise expect insufficient delegation error on further claim attempts
+            else {
+                vm.startPrank(delegates[i].delegate);
+                vm.expectRevert(abi.encodeWithSelector(Airdrop.InsufficientDelegation.selector, delegates[i].allowance, claimed));
+                a.claim(airdrop[i].receiver, airdrop[i].amount, proof);
+                vm.stopPrank();
+            }
+            // Check that claimed amounts are still the same for both cases
+            assertEq(claimed, a.claimed(airdrop[i].receiver));
+            assertEq(claimed, a.beneficiaryClaimed(airdrop[i].receiver, delegates[i].delegate));
+            assertEq(claimed, a.balanceOf(delegates[i].delegate));
+        }
     }
 }

--- a/test/examples/Airdrop.t.sol
+++ b/test/examples/Airdrop.t.sol
@@ -90,12 +90,11 @@ contract AirdropTest is Test {
         // Test that total supply is expected
         assertEq(totalSupply_, a.balanceOf(address(a)));
         // Try to claim with bogus proof
-        for (uint256 i=0; i<n; i++) {
-            (uint256 bogusAmount, address bogusReceiver, bytes32 bogusData,) =
-            generateAirdropRecord(amountSeed, addressSeed, i);
+        for (uint256 i = 0; i < n; i++) {
+            (uint256 bogusAmount, address bogusReceiver, bytes32 bogusData,) = generateAirdropRecord(amountSeed, addressSeed, i);
             bytes32[] memory proof = m.getProof(airdropData, i);
             vm.startPrank(bogusReceiver);
-            vm.expectRevert(abi.encodeWithSelector(Airdrop.InvalidProof.selector, root,  proof, bogusData));
+            vm.expectRevert(abi.encodeWithSelector(Airdrop.InvalidProof.selector, root, proof, bogusData));
             a.claim(bogusReceiver, bogusAmount, proof);
             vm.stopPrank();
         }

--- a/test/examples/Airdrop.t.sol
+++ b/test/examples/Airdrop.t.sol
@@ -106,7 +106,7 @@ contract AirdropTest is Test {
             bytes32[] memory proof = merkle.getProof(airdropHashes, i);
             vm.startPrank(bogusReceiver);
             vm.expectRevert("Invalid Proof");
-            airdrop.claim(bogusAmount, bogusReceiver, bogusAmount, proof);
+            airdrop.claim(bogusReceiver, bogusAmount, bogusAmount, proof);
             vm.stopPrank();
         }
         // Claim airdrop for every receiver
@@ -115,9 +115,9 @@ contract AirdropTest is Test {
             uint256 amount = airdropData[i].amount;
             bytes32[] memory proof = merkle.getProof(airdropHashes, i);
             vm.startPrank(claimant);
-            airdrop.claim(amount, claimant, amount, proof);
+            airdrop.claim(claimant, amount, amount, proof);
             // Claim again to ensure accounting is working
-            airdrop.claim(amount, claimant, amount, proof);
+            airdrop.claim(claimant, amount, amount, proof);
             vm.stopPrank();
             // Check that tokens are received
             assertEq(amount, airdrop.balanceOf(claimant));
@@ -166,7 +166,7 @@ contract AirdropTest is Test {
             bytes32[] memory proof = merkle.getProof(airdropHashes, i);
             vm.startPrank(delegateData[i].delegate);
             vm.expectRevert("Insufficient Delegation");
-            airdrop.claim(amount, claimant, amount, proof);
+            airdrop.claim(claimant, amount, amount, proof);
             vm.stopPrank();
         }
         // Delegate and claim airdrop
@@ -178,7 +178,7 @@ contract AirdropTest is Test {
             // Delegate claims airdrop
             vm.startPrank(delegateData[i].delegate);
             bytes32[] memory proof = merkle.getProof(airdropHashes, i);
-            airdrop.claim(airdropData[i].amount, airdropData[i].receiver, airdropData[i].amount, proof);
+            airdrop.claim(airdropData[i].receiver, airdropData[i].amount, airdropData[i].amount, proof);
             vm.stopPrank();
             uint256 claimed = Math.min(delegateData[i].allowance, airdropData[i].amount);
             // Check that claimed is as expected
@@ -190,14 +190,14 @@ contract AirdropTest is Test {
             // If claimed is airdrop amount, delegate tries to claim again but they receive no further tokens
             if (claimed == airdropData[i].amount) {
                 vm.startPrank(delegateData[i].delegate);
-                airdrop.claim(airdropData[i].amount, airdropData[i].receiver, airdropData[i].amount, proof);
+                airdrop.claim(airdropData[i].receiver, airdropData[i].amount, airdropData[i].amount, proof);
                 vm.stopPrank();
             }
             // Otherwise expect insufficient delegation error on further claim attempts
             else {
                 vm.startPrank(delegateData[i].delegate);
                 vm.expectRevert("Insufficient Delegation");
-                airdrop.claim(airdropData[i].amount, airdropData[i].receiver, airdropData[i].amount, proof);
+                airdrop.claim(airdropData[i].receiver, airdropData[i].amount, airdropData[i].amount, proof);
                 vm.stopPrank();
             }
             // Check that claimed amounts are still the same for both cases
@@ -207,7 +207,7 @@ contract AirdropTest is Test {
             // Get vault to claim remaining tokens
             uint256 remainingClaim = airdropData[i].amount - airdrop.claimed(airdropData[i].receiver);
             vm.startPrank(airdropData[i].receiver);
-            airdrop.claim(airdropData[i].amount, airdropData[i].receiver, airdropData[i].amount, proof);
+            airdrop.claim(airdropData[i].receiver, airdropData[i].amount, airdropData[i].amount, proof);
             vm.stopPrank();
             // Check balances for vault and delegate (again)
             assertEq(claimed + remainingClaim, airdrop.claimed(airdropData[i].receiver));

--- a/test/examples/Airdrop.t.sol
+++ b/test/examples/Airdrop.t.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.19;
+
+import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+
+import {Merkle} from "murky/Merkle.sol";
+import {Airdrop} from "../../src/examples/Airdrop.sol";
+import {DelegationRegistry} from "src/DelegationRegistry.sol";
+
+contract AirdropTest is Test {
+    Merkle m;
+
+    DelegationRegistry r;
+
+    struct AirdropRecord {
+        address receiver;
+        uint256 amount;
+    }
+
+    uint256 constant maxAirdropSize = 100;
+
+    Airdrop a;
+
+    AirdropRecord[] airdrop;
+
+    bytes32[] airdropData;
+
+    bytes32 root;
+
+    function setUp() public {
+        m = new Merkle();
+        r = new DelegationRegistry();
+    }
+
+    function createAirdrop(uint256 addressSeed, uint256 amountSeed, uint256 n) internal {
+        for (uint256 i = 0; i < n; i++) {
+            (,, bytes32 data, AirdropRecord memory record) = generateAirdropRecord(addressSeed, amountSeed, i);
+            // Append to list
+            airdropData.push(data);
+            // Add to airdrop mapping
+            airdrop.push(record);
+        }
+        root = m.getRoot(airdropData);
+    }
+
+    function generateAirdropRecord(uint256 addressSeed, uint256 amountSeed, uint256 i)
+        internal
+        pure
+        returns (uint256 amount, address receiver, bytes32 data, AirdropRecord memory record)
+    {
+        amount = 1 + (uint256(keccak256(abi.encode(amountSeed, i))) % 2 ** 200);
+        receiver = address(bytes20(keccak256(abi.encode(addressSeed, i))));
+        data = keccak256(abi.encodePacked(receiver, amount));
+        record = AirdropRecord({receiver: receiver, amount: amount});
+    }
+
+    function testCreateAirdrop(uint256 addressSeed, uint256 amountSeed, uint256 n, uint256 x) public {
+        vm.assume(n > 1 && n < maxAirdropSize);
+        createAirdrop(addressSeed, amountSeed, n);
+        // Test random value
+        vm.assume(x < n);
+        (uint256 amount, address receiver,,) = generateAirdropRecord(addressSeed, amountSeed, x);
+        // Load struct and data from storage
+        AirdropRecord memory record = airdrop[x];
+        bytes32 data = keccak256(abi.encodePacked(receiver, amount));
+        assertEq(amount, record.amount);
+        assertEq(receiver, record.receiver);
+        assertEq(data, airdropData[x]);
+        // Generate proof and verify
+        bytes32[] memory proof = m.getProof(airdropData, x);
+        assertTrue(m.verifyProof(root, proof, data));
+    }
+
+    function testAirdropWithoutDelegate(uint256 addressSeed, uint256 amountSeed, uint256 n, address referenceToken) public {
+        vm.assume(n > 1 && n < maxAirdropSize && addressSeed != amountSeed);
+        createAirdrop(addressSeed, amountSeed, n);
+        // Calculate total tokens to mint
+        uint256 totalSupply_;
+        for (uint256 i; i < n; i++) {
+            totalSupply_ += airdrop[i].amount;
+        }
+        // Create airdrop token
+        a = new Airdrop(address(r), totalSupply_, referenceToken, root, address(m));
+        // Check data is stored correctly in token
+        assertEq(address(m), address(a.m()));
+        assertEq(address(r), address(a.r()));
+        assertEq(root, a.merkleRoot());
+        assertEq(referenceToken, a.referenceToken());
+        // Test that total supply is expected
+        assertEq(totalSupply_, a.balanceOf(address(a)));
+        // Try to claim with bogus proof
+        for (uint256 i=0; i<n; i++) {
+            (uint256 bogusAmount, address bogusReceiver, bytes32 bogusData,) =
+            generateAirdropRecord(amountSeed, addressSeed, i);
+            bytes32[] memory proof = m.getProof(airdropData, i);
+            vm.startPrank(bogusReceiver);
+            vm.expectRevert(abi.encodeWithSelector(Airdrop.InvalidProof.selector, root,  proof, bogusData));
+            a.claim(bogusReceiver, bogusAmount, proof);
+            vm.stopPrank();
+        }
+        // Claim airdrop for every receiver
+        for (uint256 i = 0; i < n; i++) {
+            address claimant = airdrop[i].receiver;
+            uint256 amount = airdrop[i].amount;
+            bytes32[] memory proof = m.getProof(airdropData, i);
+            vm.startPrank(claimant);
+            a.claim(claimant, amount, proof);
+            // Claim again to ensure accounting is working
+            a.claim(claimant, amount, proof);
+            vm.stopPrank();
+            // Check that tokens are received
+            assertEq(amount, a.balanceOf(claimant));
+            // Check that claimed mapping is updated
+            assertEq(amount, a.claimed(claimant));
+        }
+        // Verify that contract no longer has any tokens
+        assertEq(0, a.balanceOf(address(a)));
+    }
+}


### PR DESCRIPTION
I've made some major changes to the v2 registry, here's a summary:

1. Added two new enumeration values to the `DelegationType`: `BALANCE` and `TOKEN_BALANCE`. These values represent delegations for fungible token balances and specific token balances (e.g. a ERC1155 token balance), respectively.

2. Added a new field to the `DelegationInfo` struct: `balance`. This stores the delegated balance for fungible tokens and specific tokens, respectively.

3. Added two new events: `DelegateForBalance` and `DelegateForTokenBalance`. These events are emitted when a user delegates a fungible balance and when a user delegates a specific token with a specific balance, respectively.

4. Added two new functions: `delegateForBalance` and `delegateForTokenBalance`. These functions allow a user to delegate a fungible token balance and a specific token balance, respectively.

5. Added two new read functions: `checkDelegateForBalance` and `checkDelegateForTokenBalance`. These functions enable an on-chain verification of whether an address is delegated to act on behalf of a fungible token balance or a specific token balance.

6. Created an example of an airdrop which implements delegated balances (see gitbook review request for demo how to).

Note on "continuous" balances: the idea with this new class of balance delegations is that they are continuous and their values in the registry cannot be decremented if they are "used".

Reviews welcome and let me know if you have any questions or concerns. :)
