### PR TITLE
Replace batchDelegate with multicall

### DIFF
--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -29,17 +29,6 @@ interface IDelegateRegistry {
         uint256 amount;
     }
 
-    /// @notice Struct for batch delegations
-    struct BatchDelegation {
-        DelegationType type_;
-        bool enable;
-        address delegate;
-        bytes32 rights;
-        address contract_;
-        uint256 tokenId;
-        uint256 amount;
-    }
-
     /// @notice Emitted when a user delegates rights for their entire wallet
     event AllDelegated(address indexed vault, address indexed delegate, bytes32 rights, bool enable);
 
@@ -62,10 +51,9 @@ interface IDelegateRegistry {
      */
 
     /**
-     * @notice Batch several delegations into a single transactions
-     * @param delegations An array of SetDelegation structs
+     * @notice Call multiple registry functions at once with multicall
      */
-    function batchDelegate(BatchDelegation[] calldata delegations) external;
+    function multicall(bytes[] calldata data) external returns (bytes[] memory results);
 
     /**
      * @notice Allow the delegate to act on your behalf for all contracts

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -116,26 +116,10 @@ contract DelegateRegistryTest is Test {
     function testBatchDelegationForAll(address vault, address delegate0, address delegate1) public {
         vm.assume(delegate0 != delegate1 && vault != address(0) && vault != address(1));
         vm.startPrank(vault);
-        IDelegateRegistry.BatchDelegation[] memory info = new IDelegateRegistry.BatchDelegation[](2);
-        info[0] = IDelegateRegistry.BatchDelegation({
-            type_: IDelegateRegistry.DelegationType.ALL,
-            enable: true,
-            delegate: delegate0,
-            contract_: address(0),
-            tokenId: 0,
-            amount: 0,
-            rights: ""
-        });
-        info[1] = IDelegateRegistry.BatchDelegation({
-            type_: IDelegateRegistry.DelegationType.ALL,
-            enable: true,
-            delegate: delegate1,
-            contract_: address(0),
-            tokenId: 0,
-            amount: 0,
-            rights: ""
-        });
-        reg.batchDelegate(info);
+        bytes[] memory batchData = new bytes[](2);
+        batchData[0] = abi.encodeWithSelector(IDelegateRegistry.delegateAll.selector, delegate0, "", true);
+        batchData[1] = abi.encodeWithSelector(IDelegateRegistry.delegateAll.selector, delegate1, "", true);
+        reg.multicall(batchData);
 
         IDelegateRegistry.Delegation[] memory delegations = reg.getDelegationsForVault(vault);
         assertEq(delegations.length, 2);

--- a/test/GasBenchmark.t.sol
+++ b/test/GasBenchmark.t.sol
@@ -10,52 +10,50 @@ import {IDelegateRegistry as IRegistry} from "src/IDelegateRegistry.sol";
 contract GasBenchmark is Test {
     Registry registry;
 
-    function setUp() public {
-        registry = new Registry();
-    }
+    function setUp() public {}
 
-    function _createDelegations(bytes32 seed) private pure returns (IRegistry.BatchDelegation[] memory delegations) {
-        delegations = new IRegistry.BatchDelegation[](5);
-        delegations[0] = IRegistry.BatchDelegation({
+    function _createDelegations(bytes32 seed) private pure returns (IRegistry.Delegation[] memory delegations) {
+        delegations = new IRegistry.Delegation[](5);
+        delegations[0] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.ALL,
-            enable: true,
             delegate: address(bytes20(keccak256(abi.encode(seed, "ALL", "delegate")))),
+            vault: address(0),
             rights: "",
             contract_: address(0),
             tokenId: 0,
             amount: 0
         });
-        delegations[1] = IRegistry.BatchDelegation({
+        delegations[1] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.CONTRACT,
-            enable: true,
             delegate: address(bytes20(keccak256(abi.encode(seed, "CONTRACT", "delegate")))),
+            vault: address(0),
             rights: "",
             contract_: address(bytes20(keccak256(abi.encode(seed, "CONTRACT", "contract_")))),
             tokenId: 0,
             amount: 0
         });
-        delegations[2] = IRegistry.BatchDelegation({
+        delegations[2] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.ERC721,
-            enable: true,
             delegate: address(bytes20(keccak256(abi.encode(seed, "ERC721", "delegate")))),
+            vault: address(0),
             rights: "",
             contract_: address(bytes20(keccak256(abi.encode(seed, "ERC721", "contract_")))),
             tokenId: uint256(keccak256(abi.encode(seed, "ERC721", "tokenId"))),
             amount: 0
         });
-        delegations[3] = IRegistry.BatchDelegation({
+        delegations[3] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.ERC20,
-            enable: true,
             delegate: address(bytes20(keccak256(abi.encode(seed, "ERC20", "delegate")))),
+            vault: address(0),
             rights: "",
             contract_: address(bytes20(keccak256(abi.encode(seed, "ERC20", "contract_")))),
             tokenId: 0,
             amount: uint256(keccak256(abi.encode(seed, "ERC20", "amount")))
         });
-        delegations[4] = IRegistry.BatchDelegation({
+        delegations[4] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.ERC1155,
-            enable: true,
             delegate: address(bytes20(keccak256(abi.encode(seed, "ERC1155", "delegate")))),
+            vault: address(0),
             rights: "",
             contract_: address(bytes20(keccak256(abi.encode(seed, "ERC1155", "contract_")))),
             tokenId: uint256(keccak256(abi.encode(seed, "ERC1155", "tokenId"))),
@@ -65,30 +63,61 @@ contract GasBenchmark is Test {
 
     function testGas(address vault, bytes32 seed) public {
         vm.assume(vault > address(1));
-        // Benchmark batch delegate
-        registry.batchDelegate(_createDelegations(keccak256(abi.encode(seed, "batch"))));
-        // Benchmark delegate all
-        IRegistry.BatchDelegation[] memory delegations = _createDelegations(keccak256(abi.encode(seed, "delegations")));
-        registry.delegateAll(delegations[0].delegate, delegations[0].rights, delegations[0].enable);
-        // Benchmark delegate contract
-        registry.delegateContract(delegations[1].delegate, delegations[1].contract_, delegations[1].rights, delegations[1].enable);
-        // Benchmark delegate erc721
-        registry.delegateERC721(delegations[2].delegate, delegations[2].contract_, delegations[2].tokenId, delegations[2].rights, delegations[2].enable);
-        // Benchmark delegate erc20
-        registry.delegateERC20(delegations[3].delegate, delegations[3].contract_, delegations[3].amount, delegations[3].rights, delegations[3].enable);
-        // Benchmark delegate erc1155
-        registry.delegateERC1155(
-            delegations[4].delegate, delegations[4].contract_, delegations[4].tokenId, delegations[4].amount, delegations[4].rights, delegations[4].enable
-        );
-        // Benchmark check delegate all
+        // Benchmark delegate all and check all
+        registry = new Registry();
+        IRegistry.Delegation[] memory delegations = _createDelegations(keccak256(abi.encode(seed, "delegations")));
+        registry.delegateAll(delegations[0].delegate, delegations[0].rights, true);
         registry.checkDelegateForAll(delegations[0].delegate, vault, delegations[0].rights);
-        // Benchmark check delegate contract
+        // Benchmark delegate contract and check contract
+        registry = new Registry();
+        registry.delegateContract(delegations[1].delegate, delegations[1].contract_, delegations[1].rights, true);
         registry.checkDelegateForContract(delegations[1].delegate, vault, delegations[1].contract_, delegations[1].rights);
-        // Benchmark check delegate erc721
+        // Benchmark delegate erc721 and check erc721
+        registry = new Registry();
+        registry.delegateERC721(delegations[2].delegate, delegations[2].contract_, delegations[2].tokenId, delegations[2].rights, true);
         registry.checkDelegateForERC721(delegations[2].delegate, vault, delegations[2].contract_, delegations[2].tokenId, delegations[2].rights);
-        // Benchmark check delegate for erc20
+        // Benchmark delegate erc20 and check erc20
+        registry = new Registry();
+        registry.delegateERC20(delegations[3].delegate, delegations[3].contract_, delegations[3].amount, delegations[3].rights, true);
         registry.checkDelegateForERC20(delegations[3].delegate, vault, delegations[3].contract_, delegations[3].rights);
-        // Benchmark check delegate for erc1155
+        // Benchmark delegate erc1155 and check erc20
+        registry = new Registry();
+        registry.delegateERC1155(delegations[4].delegate, delegations[4].contract_, delegations[4].tokenId, delegations[4].amount, delegations[4].rights, true);
         registry.checkDelegateForERC1155(delegations[4].delegate, vault, delegations[4].contract_, delegations[4].tokenId, delegations[4].rights);
+        // Benchmark multicall
+        registry = new Registry();
+        IRegistry.Delegation[] memory multicallDelegations = new IRegistry.Delegation[](5);
+        multicallDelegations = _createDelegations(keccak256(abi.encode(seed, "multicall")));
+        bytes[] memory data = new bytes[](5);
+        data[0] = abi.encodeWithSelector(IRegistry.delegateAll.selector, multicallDelegations[0].delegate, multicallDelegations[0].rights, true);
+        data[1] = abi.encodeWithSelector(
+            IRegistry.delegateContract.selector, multicallDelegations[1].delegate, multicallDelegations[1].contract_, multicallDelegations[1].rights, true
+        );
+        data[2] = abi.encodeWithSelector(
+            IRegistry.delegateERC721.selector,
+            multicallDelegations[2].delegate,
+            multicallDelegations[2].contract_,
+            multicallDelegations[2].tokenId,
+            multicallDelegations[2].rights,
+            true
+        );
+        data[3] = abi.encodeWithSelector(
+            IRegistry.delegateERC20.selector,
+            multicallDelegations[3].delegate,
+            multicallDelegations[3].contract_,
+            multicallDelegations[3].amount,
+            multicallDelegations[3].rights,
+            true
+        );
+        data[4] = abi.encodeWithSelector(
+            IRegistry.delegateERC1155.selector,
+            multicallDelegations[4].delegate,
+            multicallDelegations[4].contract_,
+            multicallDelegations[4].tokenId,
+            multicallDelegations[4].amount,
+            multicallDelegations[4].rights,
+            true
+        );
+        registry.multicall(data);
     }
 }


### PR DESCRIPTION

Modest gas benefits, and much cleaner / simpler (smaller function, removes need for `BatchDelegation` struct). Also allows projects to multicall other registry functions without going through an external multicall contract. Encoding is very simple on the front end as well e.g.:

    var batch = [];
    
    const delegation1 = delegateRegistry.methods.delegateAll([delegate1, "", true]).encodeABI();
    
    const delegation2 = delegateRegistry.methods.delegateERC20([delegate2, contract2, 10, "", true]).encodeABI();
    
    batch.push(delegation1);
    
    batch.push(delegation2);
    
    try {
      await delegateRegistry.methods.multicall(batch).send(); 
    } catch(err) {
      console.log(err);
    }
