### PR TITLE
gas optimizations

### DIFF
--- a/gasbenchmark10mil
+++ b/gasbenchmark10mil
@@ -1,16 +1,16 @@
 | src/DelegateRegistry.sol:DelegateRegistry contract |                 |        |        |        |         |
 |----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                    | Deployment Size |        |        |        |         |
-| 1780269                                            | 8924            |        |        |        |         |
+| 1721206                                            | 8629            |        |        |        |         |
 | Function Name                                      | min             | avg    | median | max    | # calls |
-| checkDelegateForAll                                | 3269            | 3269   | 3269   | 3269   | 1       |
-| checkDelegateForContract                           | 6132            | 6132   | 6132   | 6132   | 1       |
-| checkDelegateForERC1155                            | 9063            | 9063   | 9063   | 9063   | 1       |
-| checkDelegateForERC20                              | 8973            | 8973   | 8973   | 8973   | 1       |
-| checkDelegateForERC721                             | 9058            | 9058   | 9058   | 9058   | 1       |
-| delegateAll                                        | 136085          | 136085 | 136085 | 136085 | 2       |
-| delegateContract                                   | 136852          | 147802 | 147802 | 158752 | 2       |
-| delegateERC1155                                    | 181699          | 192649 | 192649 | 203599 | 2       |
-| delegateERC20                                      | 159295          | 170245 | 170245 | 181195 | 2       |
-| delegateERC721                                     | 159316          | 170266 | 170266 | 181216 | 2       |
-| multicall                                          | 778846          | 778846 | 778846 | 778846 | 1       |
+| checkDelegateForAll                                | 3328            | 3328   | 3328   | 3328   | 1       |
+| checkDelegateForContract                           | 6255            | 6255   | 6255   | 6255   | 1       |
+| checkDelegateForERC1155                            | 9251            | 9251   | 9251   | 9251   | 1       |
+| checkDelegateForERC20                              | 9161            | 9161   | 9161   | 9161   | 1       |
+| checkDelegateForERC721                             | 9245            | 9245   | 9245   | 9245   | 1       |
+| delegateAll                                        | 136097          | 136097 | 136097 | 136097 | 2       |
+| delegateContract                                   | 136870          | 147820 | 147820 | 158770 | 2       |
+| delegateERC1155                                    | 181720          | 192670 | 192670 | 203620 | 2       |
+| delegateERC20                                      | 159313          | 170263 | 170263 | 181213 | 2       |
+| delegateERC721                                     | 159323          | 170273 | 170273 | 181223 | 2       |
+| multicall                                          | 778582          | 778582 | 778582 | 778582 | 1       |

--- a/gasbenchmark10mil
+++ b/gasbenchmark10mil
@@ -1,16 +1,16 @@
 | src/DelegateRegistry.sol:DelegateRegistry contract |                 |        |        |        |         |
 |----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                    | Deployment Size |        |        |        |         |
-| 1713999                                            | 8593            |        |        |        |         |
+| 1692178                                            | 8484            |        |        |        |         |
 | Function Name                                      | min             | avg    | median | max    | # calls |
-| checkDelegateForAll                                | 3328            | 3328   | 3328   | 3328   | 1       |
-| checkDelegateForContract                           | 6255            | 6255   | 6255   | 6255   | 1       |
-| checkDelegateForERC1155                            | 9251            | 9251   | 9251   | 9251   | 1       |
-| checkDelegateForERC20                              | 9161            | 9161   | 9161   | 9161   | 1       |
-| checkDelegateForERC721                             | 9245            | 9245   | 9245   | 9245   | 1       |
-| delegateAll                                        | 136097          | 136097 | 136097 | 136097 | 2       |
+| checkDelegateForAll                                | 3339            | 3339   | 3339   | 3339   | 1       |
+| checkDelegateForContract                           | 6244            | 6244   | 6244   | 6244   | 1       |
+| checkDelegateForERC1155                            | 9273            | 9273   | 9273   | 9273   | 1       |
+| checkDelegateForERC20                              | 9183            | 9183   | 9183   | 9183   | 1       |
+| checkDelegateForERC721                             | 9212            | 9212   | 9212   | 9212   | 1       |
+| delegateAll                                        | 136141          | 136141 | 136141 | 136141 | 2       |
 | delegateContract                                   | 136870          | 147820 | 147820 | 158770 | 2       |
-| delegateERC1155                                    | 181717          | 192667 | 192667 | 203617 | 2       |
-| delegateERC20                                      | 159313          | 170263 | 170263 | 181213 | 2       |
-| delegateERC721                                     | 159323          | 170273 | 170273 | 181223 | 2       |
-| multicall                                          | 778579          | 778579 | 778579 | 778579 | 1       |
+| delegateERC1155                                    | 181783          | 192733 | 192733 | 203683 | 2       |
+| delegateERC20                                      | 159290          | 170240 | 170240 | 181190 | 2       |
+| delegateERC721                                     | 159345          | 170295 | 170295 | 181245 | 2       |
+| multicall                                          | 778710          | 778710 | 778710 | 778710 | 1       |

--- a/gasbenchmark10mil
+++ b/gasbenchmark10mil
@@ -1,7 +1,7 @@
 | src/DelegateRegistry.sol:DelegateRegistry contract |                 |        |        |        |         |
 |----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                    | Deployment Size |        |        |        |         |
-| 1721206                                            | 8629            |        |        |        |         |
+| 1713999                                            | 8593            |        |        |        |         |
 | Function Name                                      | min             | avg    | median | max    | # calls |
 | checkDelegateForAll                                | 3328            | 3328   | 3328   | 3328   | 1       |
 | checkDelegateForContract                           | 6255            | 6255   | 6255   | 6255   | 1       |
@@ -10,7 +10,7 @@
 | checkDelegateForERC721                             | 9245            | 9245   | 9245   | 9245   | 1       |
 | delegateAll                                        | 136097          | 136097 | 136097 | 136097 | 2       |
 | delegateContract                                   | 136870          | 147820 | 147820 | 158770 | 2       |
-| delegateERC1155                                    | 181720          | 192670 | 192670 | 203620 | 2       |
+| delegateERC1155                                    | 181717          | 192667 | 192667 | 203617 | 2       |
 | delegateERC20                                      | 159313          | 170263 | 170263 | 181213 | 2       |
 | delegateERC721                                     | 159323          | 170273 | 170273 | 181223 | 2       |
-| multicall                                          | 778582          | 778582 | 778582 | 778582 | 1       |
+| multicall                                          | 778579          | 778579 | 778579 | 778579 | 1       |

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -64,7 +64,7 @@ contract DelegateRegistry is IDelegateRegistry {
             _writeDelegation(location, StoragePositions.vault, DELEGATION_EXISTED);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
-        emit AllDelegated(msg.sender, delegate, rights, enable);
+        emit DelegateAll(msg.sender, delegate, rights, enable);
     }
 
     /// @inheritdoc IDelegateRegistry
@@ -83,7 +83,7 @@ contract DelegateRegistry is IDelegateRegistry {
             _writeDelegation(location, StoragePositions.vault, DELEGATION_EXISTED);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
-        emit ContractDelegated(msg.sender, delegate, contract_, rights, enable);
+        emit DelegateContract(msg.sender, delegate, contract_, rights, enable);
     }
 
     /// @inheritdoc IDelegateRegistry
@@ -104,7 +104,7 @@ contract DelegateRegistry is IDelegateRegistry {
             _writeDelegation(location, StoragePositions.tokenId, "");
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
-        emit ERC721Delegated(msg.sender, delegate, contract_, tokenId, rights, enable);
+        emit DelegateERC721(msg.sender, delegate, contract_, tokenId, rights, enable);
     }
 
     // @inheritdoc IDelegateRegistry
@@ -125,7 +125,7 @@ contract DelegateRegistry is IDelegateRegistry {
             _writeDelegation(location, StoragePositions.amount, "");
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
-        emit ERC20Delegated(msg.sender, delegate, contract_, amount, rights, enable);
+        emit DelegateERC20(msg.sender, delegate, contract_, amount, rights, enable);
     }
 
     /**
@@ -151,7 +151,7 @@ contract DelegateRegistry is IDelegateRegistry {
             _writeDelegation(location, StoragePositions.tokenId, "");
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
-        emit ERC1155Delegated(msg.sender, delegate, contract_, tokenId, amount, rights, enable);
+        emit DelegateERC1155(msg.sender, delegate, contract_, tokenId, amount, rights, enable);
     }
 
     /**
@@ -262,9 +262,9 @@ contract DelegateRegistry is IDelegateRegistry {
             for (uint256 i = 0; i < hashes.length; ++i) {
                 location = _computeDelegationLocation(hashes[i]);
                 vault = _loadDelegationAddress(location, StoragePositions.vault);
-                if (vault == address(1) || vault == address(0)) {
+                if (vault == DELEGATION_UNKNOWN || vault == DELEGATION_EXISTED) {
                     delegations[i] = Delegation({
-                        type_: _decodeLastByteToType(hashes[i]),
+                        type_: DelegationType.NONE,
                         delegate: address(0),
                         vault: address(0),
                         rights: "",

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -263,15 +263,8 @@ contract DelegateRegistry is IDelegateRegistry {
                 location = _computeDelegationLocation(hashes[i]);
                 vault = _loadDelegationAddress(location, StoragePositions.from);
                 if (vault == DELEGATION_EMPTY || vault == DELEGATION_REVOKED) {
-                    delegations[i] = Delegation({
-                        type_: DelegationType.NONE,
-                        to: address(0),
-                        from: address(0),
-                        rights: "",
-                        amount: 0,
-                        contract_: address(0),
-                        tokenId: 0
-                    });
+                    delegations[i] =
+                        Delegation({type_: DelegationType.NONE, to: address(0), from: address(0), rights: "", amount: 0, contract_: address(0), tokenId: 0});
                 } else {
                     delegations[i] = Delegation({
                         type_: _decodeLastByteToType(hashes[i]),
@@ -422,16 +415,18 @@ contract DelegateRegistry is IDelegateRegistry {
         uint256 hashesLength = hashes.length;
         bytes32 hash;
         bytes32[] memory filteredHashes = new bytes32[](hashesLength);
-        for (uint256 i = 0; i < hashesLength; ++i) {
-            hash = hashes[i];
-            if (_loadDelegationAddress(_computeDelegationLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) {
-                filteredHashes[count] = hash;
-                ++count;
+        unchecked {
+            for (uint256 i = 0; i < hashesLength; ++i) {
+                hash = hashes[i];
+                if (_loadDelegationAddress(_computeDelegationLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) {
+                    filteredHashes[count] = hash;
+                    ++count;
+                }
             }
-        }
-        validHashes = new bytes32[](count);
-        for (uint256 i = 0; i < count; ++i) {
-            validHashes[i] = filteredHashes[i];
+            validHashes = new bytes32[](count);
+            for (uint256 i = 0; i < count; ++i) {
+                validHashes[i] = filteredHashes[i];
+            }
         }
     }
 

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -22,8 +22,8 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @dev Standardizes storage positions of delegation data
     enum StoragePositions {
-        delegate,
-        vault,
+        to,
+        from,
         rights,
         contract_,
         tokenId,
@@ -54,14 +54,14 @@ contract DelegateRegistry is IDelegateRegistry {
     function delegateAll(address to, bytes32 rights, bool enable) external override {
         bytes32 hash = _computeDelegationHashForAll(to, rights, msg.sender);
         bytes32 location = _computeDelegationLocation(hash);
-        if (_loadDelegationAddress(location, StoragePositions.vault) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
-            _writeDelegation(location, StoragePositions.delegate, to);
-            _writeDelegation(location, StoragePositions.vault, msg.sender);
+            _writeDelegation(location, StoragePositions.to, to);
+            _writeDelegation(location, StoragePositions.from, msg.sender);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
         } else {
-            _writeDelegation(location, StoragePositions.delegate, "");
-            _writeDelegation(location, StoragePositions.vault, DELEGATION_REVOKED);
+            _writeDelegation(location, StoragePositions.to, "");
+            _writeDelegation(location, StoragePositions.from, DELEGATION_REVOKED);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
         emit DelegateAll(msg.sender, to, rights, enable);
@@ -71,16 +71,16 @@ contract DelegateRegistry is IDelegateRegistry {
     function delegateContract(address to, address contract_, bytes32 rights, bool enable) external override {
         bytes32 hash = _computeDelegationHashForContract(contract_, to, rights, msg.sender);
         bytes32 location = _computeDelegationLocation(hash);
-        if (_loadDelegationAddress(location, StoragePositions.vault) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
-            _writeDelegation(location, StoragePositions.delegate, to);
-            _writeDelegation(location, StoragePositions.vault, msg.sender);
+            _writeDelegation(location, StoragePositions.to, to);
+            _writeDelegation(location, StoragePositions.from, msg.sender);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
         } else {
             _writeDelegation(location, StoragePositions.contract_, "");
-            _writeDelegation(location, StoragePositions.delegate, "");
-            _writeDelegation(location, StoragePositions.vault, DELEGATION_REVOKED);
+            _writeDelegation(location, StoragePositions.to, "");
+            _writeDelegation(location, StoragePositions.from, DELEGATION_REVOKED);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
         emit DelegateContract(msg.sender, to, contract_, rights, enable);
@@ -90,17 +90,17 @@ contract DelegateRegistry is IDelegateRegistry {
     function delegateERC721(address to, address contract_, uint256 tokenId, bytes32 rights, bool enable) external override {
         bytes32 hash = _computeDelegationHashForERC721(contract_, to, rights, tokenId, msg.sender);
         bytes32 location = _computeDelegationLocation(hash);
-        if (_loadDelegationAddress(location, StoragePositions.vault) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
-            _writeDelegation(location, StoragePositions.delegate, to);
-            _writeDelegation(location, StoragePositions.vault, msg.sender);
+            _writeDelegation(location, StoragePositions.to, to);
+            _writeDelegation(location, StoragePositions.from, msg.sender);
             _writeDelegation(location, StoragePositions.tokenId, tokenId);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
         } else {
             _writeDelegation(location, StoragePositions.contract_, "");
-            _writeDelegation(location, StoragePositions.delegate, "");
-            _writeDelegation(location, StoragePositions.vault, DELEGATION_REVOKED);
+            _writeDelegation(location, StoragePositions.to, "");
+            _writeDelegation(location, StoragePositions.from, DELEGATION_REVOKED);
             _writeDelegation(location, StoragePositions.tokenId, "");
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
@@ -111,17 +111,17 @@ contract DelegateRegistry is IDelegateRegistry {
     function delegateERC20(address to, address contract_, uint256 amount, bytes32 rights, bool enable) external override {
         bytes32 hash = _computeDelegationHashForERC20(contract_, to, rights, msg.sender);
         bytes32 location = _computeDelegationLocation(hash);
-        if (_loadDelegationAddress(location, StoragePositions.vault) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
-            _writeDelegation(location, StoragePositions.delegate, to);
-            _writeDelegation(location, StoragePositions.vault, msg.sender);
+            _writeDelegation(location, StoragePositions.to, to);
+            _writeDelegation(location, StoragePositions.from, msg.sender);
             _writeDelegation(location, StoragePositions.amount, amount);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
         } else {
             _writeDelegation(location, StoragePositions.contract_, "");
-            _writeDelegation(location, StoragePositions.delegate, "");
-            _writeDelegation(location, StoragePositions.vault, DELEGATION_REVOKED);
+            _writeDelegation(location, StoragePositions.to, "");
+            _writeDelegation(location, StoragePositions.from, DELEGATION_REVOKED);
             _writeDelegation(location, StoragePositions.amount, "");
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
         }
@@ -135,18 +135,18 @@ contract DelegateRegistry is IDelegateRegistry {
     function delegateERC1155(address to, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external override {
         bytes32 hash = _computeDelegationHashForERC1155(contract_, to, rights, tokenId, msg.sender);
         bytes32 location = _computeDelegationLocation(hash);
-        if (_loadDelegationAddress(location, StoragePositions.vault) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
-            _writeDelegation(location, StoragePositions.delegate, to);
-            _writeDelegation(location, StoragePositions.vault, msg.sender);
+            _writeDelegation(location, StoragePositions.to, to);
+            _writeDelegation(location, StoragePositions.from, msg.sender);
             _writeDelegation(location, StoragePositions.amount, amount);
             _writeDelegation(location, StoragePositions.tokenId, tokenId);
             if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
         } else {
             _writeDelegation(location, StoragePositions.contract_, "");
-            _writeDelegation(location, StoragePositions.delegate, "");
-            _writeDelegation(location, StoragePositions.vault, DELEGATION_REVOKED);
+            _writeDelegation(location, StoragePositions.to, "");
+            _writeDelegation(location, StoragePositions.from, DELEGATION_REVOKED);
             _writeDelegation(location, StoragePositions.amount, "");
             _writeDelegation(location, StoragePositions.tokenId, "");
             if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
@@ -261,7 +261,7 @@ contract DelegateRegistry is IDelegateRegistry {
         unchecked {
             for (uint256 i = 0; i < hashes.length; ++i) {
                 location = _computeDelegationLocation(hashes[i]);
-                vault = _loadDelegationAddress(location, StoragePositions.vault);
+                vault = _loadDelegationAddress(location, StoragePositions.from);
                 if (vault == DELEGATION_EMPTY || vault == DELEGATION_REVOKED) {
                     delegations[i] = Delegation({
                         type_: DelegationType.NONE,
@@ -275,7 +275,7 @@ contract DelegateRegistry is IDelegateRegistry {
                 } else {
                     delegations[i] = Delegation({
                         type_: _decodeLastByteToType(hashes[i]),
-                        delegate: _loadDelegationAddress(location, StoragePositions.delegate),
+                        delegate: _loadDelegationAddress(location, StoragePositions.to),
                         vault: vault,
                         rights: _loadDelegationBytes32(location, StoragePositions.rights),
                         amount: _loadDelegationUint(location, StoragePositions.amount),
@@ -391,7 +391,7 @@ contract DelegateRegistry is IDelegateRegistry {
         unchecked {
             for (uint256 i = 0; i < hashesLength; ++i) {
                 hash = hashes[i];
-                if (_loadDelegationAddress(_computeDelegationLocation(hash), StoragePositions.vault) > DELEGATION_REVOKED) {
+                if (_loadDelegationAddress(_computeDelegationLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) {
                     filteredHashes[count] = hash;
                     ++count;
                 }
@@ -402,10 +402,10 @@ contract DelegateRegistry is IDelegateRegistry {
             for (uint256 i = 0; i < count; ++i) {
                 hash = filteredHashes[i];
                 location = _computeDelegationLocation(hash);
-                vault = _loadDelegationAddress(location, StoragePositions.vault);
+                vault = _loadDelegationAddress(location, StoragePositions.from);
                 delegations[i] = Delegation({
                     type_: _decodeLastByteToType(hash),
-                    delegate: _loadDelegationAddress(location, StoragePositions.delegate),
+                    delegate: _loadDelegationAddress(location, StoragePositions.to),
                     vault: vault,
                     rights: _loadDelegationBytes32(location, StoragePositions.rights),
                     amount: _loadDelegationUint(location, StoragePositions.amount),
@@ -424,7 +424,7 @@ contract DelegateRegistry is IDelegateRegistry {
         bytes32[] memory filteredHashes = new bytes32[](hashesLength);
         for (uint256 i = 0; i < hashesLength; ++i) {
             hash = hashes[i];
-            if (_loadDelegationAddress(_computeDelegationLocation(hash), StoragePositions.vault) > DELEGATION_REVOKED) {
+            if (_loadDelegationAddress(_computeDelegationLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) {
                 filteredHashes[count] = hash;
                 ++count;
             }
@@ -458,6 +458,6 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @dev Helper function to establish whether a delegation is enabled
     function _validateDelegation(bytes32 location, address vault) private view returns (bool) {
-        return (_loadDelegationAddress(location, StoragePositions.vault) == vault && vault > DELEGATION_REVOKED);
+        return (_loadDelegationAddress(location, StoragePositions.from) == vault && vault > DELEGATION_REVOKED);
     }
 }

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -11,13 +11,13 @@ import {IDelegateRegistry} from "./IDelegateRegistry.sol";
  * @notice A standalone immutable registry storing delegated permissions from one wallet to another
  */
 contract DelegateRegistry is IDelegateRegistry {
-    /// @dev Only this mapping should be used to verify delegations; the other mappings are for record keeping only
+    /// @dev Only this mapping should be used to verify delegations; the other mappings are for recordkeeping only
     mapping(bytes32 delegationHash => bytes32[6] delegationStorage) internal _delegations;
 
-    /// @dev Vault delegation outbox, for pushing new hashes only
+    /// @dev Vault delegation enumeration outbox, for pushing new hashes only
     mapping(address vault => bytes32[] delegationHashes) internal _vaultDelegationHashes;
 
-    /// @dev Delegate delegation inbox, for pushing new hashes only
+    /// @dev Delegate delegation enumeration inbox, for pushing new hashes only
     mapping(address delegate => bytes32[] delegationHashes) internal _delegateDelegationHashes;
 
     /// @dev Standardizes storage positions of delegation data
@@ -233,22 +233,22 @@ contract DelegateRegistry is IDelegateRegistry {
      */
 
     /// @inheritdoc IDelegateRegistry
-    function getDelegationsForDelegate(address delegate) external view override returns (Delegation[] memory delegations) {
+    function getIncomingDelegations(address delegate) external view override returns (Delegation[] memory delegations) {
         delegations = _getValidDelegationsFromHashes(_delegateDelegationHashes[delegate]);
     }
 
     /// @inheritdoc IDelegateRegistry
-    function getDelegationsForVault(address vault) external view returns (Delegation[] memory delegations) {
+    function getOutgoingDelegations(address vault) external view returns (Delegation[] memory delegations) {
         delegations = _getValidDelegationsFromHashes(_vaultDelegationHashes[vault]);
     }
 
     /// @inheritdoc IDelegateRegistry
-    function getDelegationHashesForDelegate(address delegate) external view returns (bytes32[] memory delegationHashes) {
+    function getIncomingDelegationHashes(address delegate) external view returns (bytes32[] memory delegationHashes) {
         delegationHashes = _getValidDelegationHashesFromHashes(_delegateDelegationHashes[delegate]);
     }
 
     /// @inheritdoc IDelegateRegistry
-    function getDelegationHashesForVault(address vault) external view returns (bytes32[] memory delegationHashes) {
+    function getOutgoingDelegationHashes(address vault) external view returns (bytes32[] memory delegationHashes) {
         delegationHashes = _getValidDelegationHashesFromHashes(_vaultDelegationHashes[vault]);
     }
 
@@ -381,7 +381,7 @@ contract DelegateRegistry is IDelegateRegistry {
         }
     }
 
-    /// @dev Helper function that takes an array of delegation hashes and returns an array of Delegation structs with their on chain information
+    /// @dev Helper function that takes an array of delegation hashes and returns an array of Delegation structs with their onchain information
     function _getValidDelegationsFromHashes(bytes32[] storage hashes) private view returns (Delegation[] memory delegations) {
         uint256 count = 0;
         uint256 hashesLength = hashes.length;

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -15,10 +15,10 @@ contract DelegateRegistry is IDelegateRegistry {
     mapping(bytes32 delegationHash => bytes32[6] delegationStorage) internal _delegations;
 
     /// @dev Vault delegation enumeration outbox, for pushing new hashes only
-    mapping(address vault => bytes32[] delegationHashes) internal _outgoingDelegationHashes;
+    mapping(address from => bytes32[] delegationHashes) internal _outgoingDelegationHashes;
 
     /// @dev Delegate delegation enumeration inbox, for pushing new hashes only
-    mapping(address delegate => bytes32[] delegationHashes) internal _incomingDelegationHashes;
+    mapping(address to => bytes32[] delegationHashes) internal _incomingDelegationHashes;
 
     /// @dev Standardizes storage positions of delegation data
     enum StoragePositions {
@@ -265,8 +265,8 @@ contract DelegateRegistry is IDelegateRegistry {
                 if (vault == DELEGATION_EMPTY || vault == DELEGATION_REVOKED) {
                     delegations[i] = Delegation({
                         type_: DelegationType.NONE,
-                        delegate: address(0),
-                        vault: address(0),
+                        to: address(0),
+                        from: address(0),
                         rights: "",
                         amount: 0,
                         contract_: address(0),
@@ -275,8 +275,8 @@ contract DelegateRegistry is IDelegateRegistry {
                 } else {
                     delegations[i] = Delegation({
                         type_: _decodeLastByteToType(hashes[i]),
-                        delegate: _loadDelegationAddress(location, StoragePositions.to),
-                        vault: vault,
+                        to: _loadDelegationAddress(location, StoragePositions.to),
+                        from: vault,
                         rights: _loadDelegationBytes32(location, StoragePositions.rights),
                         amount: _loadDelegationUint(location, StoragePositions.amount),
                         contract_: _loadDelegationAddress(location, StoragePositions.contract_),
@@ -405,8 +405,8 @@ contract DelegateRegistry is IDelegateRegistry {
                 vault = _loadDelegationAddress(location, StoragePositions.from);
                 delegations[i] = Delegation({
                     type_: _decodeLastByteToType(hash),
-                    delegate: _loadDelegationAddress(location, StoragePositions.to),
-                    vault: vault,
+                    to: _loadDelegationAddress(location, StoragePositions.to),
+                    from: vault,
                     rights: _loadDelegationBytes32(location, StoragePositions.rights),
                     amount: _loadDelegationUint(location, StoragePositions.amount),
                     contract_: _loadDelegationAddress(location, StoragePositions.contract_),
@@ -457,7 +457,7 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @dev Helper function to establish whether a delegation is enabled
-    function _validateDelegation(bytes32 location, address vault) private view returns (bool) {
-        return (_loadDelegationAddress(location, StoragePositions.from) == vault && vault > DELEGATION_REVOKED);
+    function _validateDelegation(bytes32 location, address from) private view returns (bool) {
+        return (_loadDelegationAddress(location, StoragePositions.from) == from && from > DELEGATION_REVOKED);
     }
 }

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -8,7 +8,7 @@ import {IDelegateRegistry} from "./IDelegateRegistry.sol";
  * @custom:version 2.0
  * @custom:coauthor foobar (0xfoobar)
  * @custom:coauthor mireynolds
- * @notice A standalone immutable registry storing delegated permissions from one wallet to another
+ * @notice A standalone immutable registry storing delegated permissions from one address to another
  */
 contract DelegateRegistry is IDelegateRegistry {
     /// @dev Only this mapping should be used to verify delegations; the other mappings are for recordkeeping only
@@ -179,12 +179,7 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @inheritdoc IDelegateRegistry
-    function checkDelegateForERC721(address to, address from, address contract_, uint256 tokenId, bytes32 rights)
-        external
-        view
-        override
-        returns (bool valid)
-    {
+    function checkDelegateForERC721(address to, address from, address contract_, uint256 tokenId, bytes32 rights) external view override returns (bool valid) {
         bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC721(contract_, to, "", tokenId, from));
         valid = checkDelegateForContract(to, from, contract_, "") || _validateDelegation(location, from);
         if (rights != "" && !valid) {
@@ -305,11 +300,7 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @dev Helper function to compute delegation hash for ERC721 delegation
-    function _computeDelegationHashForERC721(address contract_, address to, bytes32 rights, uint256 tokenId, address from)
-        internal
-        pure
-        returns (bytes32)
-    {
+    function _computeDelegationHashForERC721(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
         return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), DelegationType.ERC721);
     }
 
@@ -319,11 +310,7 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @dev Helper function to compute delegation hash for ERC1155 delegation
-    function _computeDelegationHashForERC1155(address contract_, address to, bytes32 rights, uint256 tokenId, address from)
-        internal
-        pure
-        returns (bytes32)
-    {
+    function _computeDelegationHashForERC1155(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
         return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), DelegationType.ERC1155);
     }
 

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -30,7 +30,7 @@ contract DelegateRegistry is IDelegateRegistry {
         amount
     }
 
-    /// @dev Standardizes vault storage flags to prevent double-writes in the delegation in/outbox if the same delegation is revoked and rewritten
+    /// @dev Standardizes from storage flags to prevent double-writes in the delegation in/outbox if the same delegation is revoked and rewritten
     address internal constant DELEGATION_EMPTY = address(0);
     address internal constant DELEGATION_REVOKED = address(1);
 
@@ -159,71 +159,71 @@ contract DelegateRegistry is IDelegateRegistry {
      */
 
     /// @inheritdoc IDelegateRegistry
-    function checkDelegateForAll(address delegate, address vault, bytes32 rights) public view override returns (bool valid) {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForAll(delegate, "", vault));
-        valid = _validateDelegation(location, vault);
+    function checkDelegateForAll(address to, address from, bytes32 rights) public view override returns (bool valid) {
+        bytes32 location = _computeDelegationLocation(_computeDelegationHashForAll(to, "", from));
+        valid = _validateDelegation(location, from);
         if (rights != "" && !valid) {
-            location = _computeDelegationLocation(_computeDelegationHashForAll(delegate, rights, vault));
-            valid = _validateDelegation(location, vault);
+            location = _computeDelegationLocation(_computeDelegationHashForAll(to, rights, from));
+            valid = _validateDelegation(location, from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
-    function checkDelegateForContract(address delegate, address vault, address contract_, bytes32 rights) public view override returns (bool valid) {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForContract(contract_, delegate, "", vault));
-        valid = checkDelegateForAll(delegate, vault, "") || _validateDelegation(location, vault);
+    function checkDelegateForContract(address to, address from, address contract_, bytes32 rights) public view override returns (bool valid) {
+        bytes32 location = _computeDelegationLocation(_computeDelegationHashForContract(contract_, to, "", from));
+        valid = checkDelegateForAll(to, from, "") || _validateDelegation(location, from);
         if (rights != "" && !valid) {
-            location = _computeDelegationLocation(_computeDelegationHashForContract(contract_, delegate, rights, vault));
-            valid = checkDelegateForAll(delegate, vault, rights) || _validateDelegation(location, vault);
+            location = _computeDelegationLocation(_computeDelegationHashForContract(contract_, to, rights, from));
+            valid = checkDelegateForAll(to, from, rights) || _validateDelegation(location, from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
-    function checkDelegateForERC721(address delegate, address vault, address contract_, uint256 tokenId, bytes32 rights)
+    function checkDelegateForERC721(address to, address from, address contract_, uint256 tokenId, bytes32 rights)
         external
         view
         override
         returns (bool valid)
     {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC721(contract_, delegate, "", tokenId, vault));
-        valid = checkDelegateForContract(delegate, vault, contract_, "") || _validateDelegation(location, vault);
+        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC721(contract_, to, "", tokenId, from));
+        valid = checkDelegateForContract(to, from, contract_, "") || _validateDelegation(location, from);
         if (rights != "" && !valid) {
-            location = _computeDelegationLocation(_computeDelegationHashForERC721(contract_, delegate, rights, tokenId, vault));
-            valid = checkDelegateForContract(delegate, vault, contract_, rights) || _validateDelegation(location, vault);
+            location = _computeDelegationLocation(_computeDelegationHashForERC721(contract_, to, rights, tokenId, from));
+            valid = checkDelegateForContract(to, from, contract_, rights) || _validateDelegation(location, from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
-    function checkDelegateForERC20(address delegate, address vault, address contract_, bytes32 rights) external view override returns (uint256 amount) {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC20(contract_, delegate, "", vault));
-        amount = checkDelegateForContract(delegate, vault, contract_, "")
+    function checkDelegateForERC20(address to, address from, address contract_, bytes32 rights) external view override returns (uint256 amount) {
+        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC20(contract_, to, "", from));
+        amount = checkDelegateForContract(to, from, contract_, "")
             ? type(uint256).max
-            : (_validateDelegation(location, vault) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
+            : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
         if (rights != "" && amount != type(uint256).max) {
-            location = _computeDelegationLocation(_computeDelegationHashForERC20(contract_, delegate, rights, vault));
-            uint256 rightsBalance = checkDelegateForContract(delegate, vault, contract_, rights)
+            location = _computeDelegationLocation(_computeDelegationHashForERC20(contract_, to, rights, from));
+            uint256 rightsBalance = checkDelegateForContract(to, from, contract_, rights)
                 ? type(uint256).max
-                : (_validateDelegation(location, vault) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
+                : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
             amount = rightsBalance > amount ? rightsBalance : amount;
         }
     }
 
     /// @inheritdoc IDelegateRegistry
-    function checkDelegateForERC1155(address delegate, address vault, address contract_, uint256 tokenId, bytes32 rights)
+    function checkDelegateForERC1155(address to, address from, address contract_, uint256 tokenId, bytes32 rights)
         external
         view
         override
         returns (uint256 amount)
     {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC1155(contract_, delegate, "", tokenId, vault));
-        amount = checkDelegateForContract(delegate, vault, contract_, "")
+        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC1155(contract_, to, "", tokenId, from));
+        amount = checkDelegateForContract(to, from, contract_, "")
             ? type(uint256).max
-            : (_validateDelegation(location, vault) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
+            : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
         if (rights != "" && amount != type(uint256).max) {
-            location = _computeDelegationLocation(_computeDelegationHashForERC1155(contract_, delegate, rights, tokenId, vault));
-            uint256 rightsBalance = checkDelegateForContract(delegate, vault, contract_, rights)
+            location = _computeDelegationLocation(_computeDelegationHashForERC1155(contract_, to, rights, tokenId, from));
+            uint256 rightsBalance = checkDelegateForContract(to, from, contract_, rights)
                 ? type(uint256).max
-                : (_validateDelegation(location, vault) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
+                : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
             amount = rightsBalance > amount ? rightsBalance : amount;
         }
     }
@@ -256,20 +256,19 @@ contract DelegateRegistry is IDelegateRegistry {
     function getDelegationsFromHashes(bytes32[] calldata hashes) external view returns (Delegation[] memory delegations) {
         delegations = new Delegation[](hashes.length);
         bytes32 location;
-        address vault;
-
+        address from;
         unchecked {
             for (uint256 i = 0; i < hashes.length; ++i) {
                 location = _computeDelegationLocation(hashes[i]);
-                vault = _loadDelegationAddress(location, StoragePositions.from);
-                if (vault == DELEGATION_EMPTY || vault == DELEGATION_REVOKED) {
+                from = _loadDelegationAddress(location, StoragePositions.from);
+                if (from == DELEGATION_EMPTY || from == DELEGATION_REVOKED) {
                     delegations[i] =
                         Delegation({type_: DelegationType.NONE, to: address(0), from: address(0), rights: "", amount: 0, contract_: address(0), tokenId: 0});
                 } else {
                     delegations[i] = Delegation({
                         type_: _decodeLastByteToType(hashes[i]),
                         to: _loadDelegationAddress(location, StoragePositions.to),
-                        from: vault,
+                        from: from,
                         rights: _loadDelegationBytes32(location, StoragePositions.rights),
                         amount: _loadDelegationUint(location, StoragePositions.amount),
                         contract_: _loadDelegationAddress(location, StoragePositions.contract_),
@@ -296,36 +295,36 @@ contract DelegateRegistry is IDelegateRegistry {
      */
 
     /// @dev Helper function to compute delegation hash for all delegation
-    function _computeDelegationHashForAll(address delegate, bytes32 rights, address vault) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(delegate, rights, vault)), DelegationType.ALL);
+    function _computeDelegationHashForAll(address to, bytes32 rights, address from) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(to, rights, from)), DelegationType.ALL);
     }
 
     /// @dev Helper function to compute delegation hash for contract delegation
-    function _computeDelegationHashForContract(address contract_, address delegate, bytes32 rights, address vault) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, delegate, rights, vault)), DelegationType.CONTRACT);
+    function _computeDelegationHashForContract(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), DelegationType.CONTRACT);
     }
 
     /// @dev Helper function to compute delegation hash for ERC721 delegation
-    function _computeDelegationHashForERC721(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault)
+    function _computeDelegationHashForERC721(address contract_, address to, bytes32 rights, uint256 tokenId, address from)
         internal
         pure
         returns (bytes32)
     {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, delegate, rights, tokenId, vault)), DelegationType.ERC721);
+        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), DelegationType.ERC721);
     }
 
     /// @dev Helper function to compute delegation hash for ERC20 delegation
-    function _computeDelegationHashForERC20(address contract_, address delegate, bytes32 rights, address vault) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, delegate, rights, vault)), DelegationType.ERC20);
+    function _computeDelegationHashForERC20(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), DelegationType.ERC20);
     }
 
     /// @dev Helper function to compute delegation hash for ERC1155 delegation
-    function _computeDelegationHashForERC1155(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault)
+    function _computeDelegationHashForERC1155(address contract_, address to, bytes32 rights, uint256 tokenId, address from)
         internal
         pure
         returns (bytes32)
     {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, delegate, rights, tokenId, vault)), DelegationType.ERC1155);
+        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), DelegationType.ERC1155);
     }
 
     /// @dev Helper function to encode the last byte of a delegation hash to its type
@@ -347,10 +346,10 @@ contract DelegateRegistry is IDelegateRegistry {
      * ----------- PRIVATE -----------
      */
 
-    /// @dev Helper function to push new delegation hashes to the delegate and vault hashes mappings
-    function _pushDelegationHashes(address vault, address delegate, bytes32 delegationHash) private {
-        _outgoingDelegationHashes[vault].push(delegationHash);
-        _incomingDelegationHashes[delegate].push(delegationHash);
+    /// @dev Helper function to push new delegation hashes to the incoming and outgoing hashes mappings
+    function _pushDelegationHashes(address from, address to, bytes32 delegationHash) private {
+        _outgoingDelegationHashes[from].push(delegationHash);
+        _incomingDelegationHashes[to].push(delegationHash);
     }
 
     /// @dev Helper function that writes bytes32 data to delegation data location at array position
@@ -380,7 +379,6 @@ contract DelegateRegistry is IDelegateRegistry {
         uint256 hashesLength = hashes.length;
         bytes32 hash;
         bytes32[] memory filteredHashes = new bytes32[](hashesLength);
-
         unchecked {
             for (uint256 i = 0; i < hashesLength; ++i) {
                 hash = hashes[i];
@@ -391,15 +389,15 @@ contract DelegateRegistry is IDelegateRegistry {
             }
             delegations = new Delegation[](count);
             bytes32 location;
-            address vault;
+            address from;
             for (uint256 i = 0; i < count; ++i) {
                 hash = filteredHashes[i];
                 location = _computeDelegationLocation(hash);
-                vault = _loadDelegationAddress(location, StoragePositions.from);
+                from = _loadDelegationAddress(location, StoragePositions.from);
                 delegations[i] = Delegation({
                     type_: _decodeLastByteToType(hash),
                     to: _loadDelegationAddress(location, StoragePositions.to),
-                    from: vault,
+                    from: from,
                     rights: _loadDelegationBytes32(location, StoragePositions.rights),
                     amount: _loadDelegationUint(location, StoragePositions.amount),
                     contract_: _loadDelegationAddress(location, StoragePositions.contract_),

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -9,8 +9,9 @@ pragma solidity >=0.8.13;
  */
 interface IDelegateRegistry {
     /// @notice Delegation type
-    enum DelegationType {
-        NONE,
+    enum DelegationType
+    // NONE,
+    {
         ALL,
         CONTRACT,
         ERC721,
@@ -45,6 +46,9 @@ interface IDelegateRegistry {
     event ERC1155Delegated(
         address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable
     );
+
+    /// @notice Emitted if multicall calldata is malformed
+    error MulticallFailed();
 
     /**
      * -----------  WRITE -----------
@@ -104,33 +108,36 @@ interface IDelegateRegistry {
     function delegateERC1155(address delegate, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external;
 
     /**
-     * ----------- Consumable -----------
+     * ----------- CHECKS -----------
      */
 
     /**
-     * @notice Returns true if the delegate is granted rights to act on your behalf for an entire vault
+     * @notice Check if a delegate can act on a vault's behalf for an entire wallet
      * @param delegate The hotwallet to act on your behalf
      * @param vault The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
+     * @return valid Whether delegate is granted to act on the vault's behalf
      */
     function checkDelegateForAll(address delegate, address vault, bytes32 rights) external view returns (bool);
 
     /**
-     * @notice Returns true if the delegate is granted rights to act on your behalf for a specific contract
+     * @notice Check if a delegate can act on a vault's behalf for a specific contract
      * @param delegate The hotwallet to act on your behalf
      * @param contract_ The address for the contract you're delegating
      * @param vault The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
+     * @return valid Whether delegate is granted to act on vault's behalf for entire wallet or that specific contract
      */
     function checkDelegateForContract(address delegate, address vault, address contract_, bytes32 rights) external view returns (bool);
 
     /**
-     * @notice Returns true if the delegate is granted rights to act on your behalf for a specific ERC721 token
+     * @notice Check if a delegate can act on a vault's behalf for a specific token
      * @param delegate The hotwallet to act on your behalf
      * @param contract_ The address for the contract you're delegating
      * @param tokenId The token id for the token you're delegating
      * @param vault The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
+     * @return valid Whether delegate is granted to act on vault's behalf for entire wallet, that contract, or that specific tokenId
      */
     function checkDelegateForERC721(address delegate, address vault, address contract_, uint256 tokenId, bytes32 rights) external view returns (bool);
 
@@ -140,6 +147,7 @@ interface IDelegateRegistry {
      * @param contract_ The address of the token contract
      * @param vault The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
+     * @return balance The delegated balance, which will be 0 if the delegation does not exist
      */
     function checkDelegateForERC20(address delegate, address vault, address contract_, bytes32 rights) external view returns (uint256);
 
@@ -150,11 +158,12 @@ interface IDelegateRegistry {
      * @param tokenId the token id for the token you're delegating the amount of
      * @param vault The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
+     * @return balance The delegated balance, which will be 0 if the delegation does not exist
      */
     function checkDelegateForERC1155(address delegate, address vault, address contract_, uint256 tokenId, bytes32 rights) external view returns (uint256);
 
     /**
-     * -----------  READ -----------
+     * ----------- ENUMERATIONS -----------
      */
 
     /**

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -168,29 +168,29 @@ interface IDelegateRegistry {
      */
 
     /**
-     * @notice Returns all enabled delegations a given delegate has been granted
-     * @param delegate The delegate to retrieve delegations for
+     * @notice Returns all enabled delegations a given delegate has received
+     * @param delegate The address to retrieve delegations for
      * @return delegations Array of Delegation structs
      */
     function getIncomingDelegations(address delegate) external view returns (Delegation[] memory delegations);
 
     /**
-     * @notice Returns all enabled delegations a vault has granted
-     * @param vault The vault to retrieve delegations for
+     * @notice Returns all enabled delegations an address has given out
+     * @param vault The address to retrieve delegations for
      * @return delegations Array of Delegation structs
      */
     function getOutgoingDelegations(address vault) external view returns (Delegation[] memory delegations);
 
     /**
-     * @notice Returns all hashes associated with enabled delegations a delegate has been granted
+     * @notice Returns all hashes associated with enabled delegations an address has received
      * @param delegate The delegate to retrieve the delegation hashes for
      * @return delegationHashes Array of delegation hashes
      */
     function getIncomingDelegationHashes(address delegate) external view returns (bytes32[] memory delegationHashes);
 
     /**
-     * @notice Returns all hashes associated with enabled delegations a vault has granted
-     * @param vault The vault to retrieve the delegation hashes for
+     * @notice Returns all hashes associated with enabled delegations an address has given out
+     * @param vault The address to retrieve the delegation hashes for
      * @return delegationHashes Array of delegation hashes
      */
     function getOutgoingDelegationHashes(address vault) external view returns (bytes32[] memory delegationHashes);
@@ -198,8 +198,7 @@ interface IDelegateRegistry {
     /**
      * @notice Returns the delegations for a given array of delegation hashes
      * @param delegationHashes is an array of hashes that correspond to delegations
-     * @return delegations Array of Delegation structs, empty structs will be returned for invalid or nonexistent
-     * delegations
+     * @return delegations Array of Delegation structs, return empty structs for nonexistent or revoked delegations
      */
     function getDelegationsFromHashes(bytes32[] calldata delegationHashes) external view returns (Delegation[] memory delegations);
 }

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -21,8 +21,8 @@ interface IDelegateRegistry {
     /// @notice Struct for returning arbitrary delegations
     struct Delegation {
         DelegationType type_;
-        address delegate;
-        address vault;
+        address to;
+        address from;
         bytes32 rights;
         address contract_;
         uint256 tokenId;

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -30,21 +30,19 @@ interface IDelegateRegistry {
     }
 
     /// @notice Emitted when an address delegates rights for their entire wallet
-    event DelegateAll(address indexed vault, address indexed delegate, bytes32 rights, bool enable);
+    event DelegateAll(address indexed from, address indexed to, bytes32 rights, bool enable);
 
     /// @notice Emitted when an address delegates rights for a specific contract
-    event DelegateContract(address indexed vault, address indexed delegate, address indexed contract_, bytes32 rights, bool enable);
+    event DelegateContract(address indexed from, address indexed to, address indexed contract_, bytes32 rights, bool enable);
 
     /// @notice Emitted when an address delegates rights for a specific ERC721 token
-    event DelegateERC721(address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, bytes32 rights, bool enable);
+    event DelegateERC721(address indexed from, address indexed to, address indexed contract_, uint256 tokenId, bytes32 rights, bool enable);
 
     /// @notice Emitted when an address delegates rights for a specific amount of ERC20 tokens
-    event DelegateERC20(address indexed vault, address indexed delegate, address indexed contract_, uint256 amount, bytes32 rights, bool enable);
+    event DelegateERC20(address indexed from, address indexed to, address indexed contract_, uint256 amount, bytes32 rights, bool enable);
 
     /// @notice Emitted when an address delegates rights for a specific amount of ERC1155 tokens
-    event DelegateERC1155(
-        address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable
-    );
+    event DelegateERC1155(address indexed from, address indexed to, address indexed contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable);
 
     /// @notice Thrown if multicall calldata is malformed
     error MulticallFailed();
@@ -62,51 +60,51 @@ interface IDelegateRegistry {
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for all contracts
-     * @param delegate The address to act as delegate
+     * @param to The address to act as delegate
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
-    function delegateAll(address delegate, bytes32 rights, bool enable) external;
+    function delegateAll(address to, bytes32 rights, bool enable) external;
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for a specific contract
-     * @param delegate The address to act as delegate
+     * @param to The address to act as delegate
      * @param contract_ The contract whose rights are being delegated
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
-    function delegateContract(address delegate, address contract_, bytes32 rights, bool enable) external;
+    function delegateContract(address to, address contract_, bytes32 rights, bool enable) external;
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for a specific ERC721 token
-     * @param delegate The address to act as delegate
+     * @param to The address to act as delegate
      * @param contract_ The contract whose rights are being delegated
      * @param tokenId The token id to delegate
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
-    function delegateERC721(address delegate, address contract_, uint256 tokenId, bytes32 rights, bool enable) external;
+    function delegateERC721(address to, address contract_, uint256 tokenId, bytes32 rights, bool enable) external;
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for a specific amount of ERC20 tokens
-     * @param delegate The address to act as delegate
+     * @param to The address to act as delegate
      * @param contract_ The address for the fungible token contract
      * @param amount The amount to delegate
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
-    function delegateERC20(address delegate, address contract_, uint256 amount, bytes32 rights, bool enable) external;
+    function delegateERC20(address to, address contract_, uint256 amount, bytes32 rights, bool enable) external;
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for a specific amount of ERC1155 tokens
-     * @param delegate The address to act as delegate
+     * @param to The address to act as delegate
      * @param contract_ The address of the contract that holds the token
      * @param tokenId The token id to delegate
      * @param amount The amount of that token id to delegate
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
-    function delegateERC1155(address delegate, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external;
+    function delegateERC1155(address to, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external;
 
     /**
      * ----------- CHECKS -----------
@@ -169,31 +167,31 @@ interface IDelegateRegistry {
 
     /**
      * @notice Returns all enabled delegations a given delegate has received
-     * @param delegate The address to retrieve delegations for
+     * @param to The address to retrieve delegations for
      * @return delegations Array of Delegation structs
      */
-    function getIncomingDelegations(address delegate) external view returns (Delegation[] memory delegations);
+    function getIncomingDelegations(address to) external view returns (Delegation[] memory delegations);
 
     /**
      * @notice Returns all enabled delegations an address has given out
-     * @param vault The address to retrieve delegations for
+     * @param from The address to retrieve delegations for
      * @return delegations Array of Delegation structs
      */
-    function getOutgoingDelegations(address vault) external view returns (Delegation[] memory delegations);
+    function getOutgoingDelegations(address from) external view returns (Delegation[] memory delegations);
 
     /**
      * @notice Returns all hashes associated with enabled delegations an address has received
-     * @param delegate The delegate to retrieve the delegation hashes for
+     * @param to The address to retrieve incoming delegation hashes for
      * @return delegationHashes Array of delegation hashes
      */
-    function getIncomingDelegationHashes(address delegate) external view returns (bytes32[] memory delegationHashes);
+    function getIncomingDelegationHashes(address to) external view returns (bytes32[] memory delegationHashes);
 
     /**
      * @notice Returns all hashes associated with enabled delegations an address has given out
-     * @param vault The address to retrieve the delegation hashes for
+     * @param from The address to retrieve outgoing delegation hashes for
      * @return delegationHashes Array of delegation hashes
      */
-    function getOutgoingDelegationHashes(address vault) external view returns (bytes32[] memory delegationHashes);
+    function getOutgoingDelegationHashes(address from) external view returns (bytes32[] memory delegationHashes);
 
     /**
      * @notice Returns the delegations for a given array of delegation hashes

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -111,55 +111,55 @@ interface IDelegateRegistry {
      */
 
     /**
-     * @notice Check if a delegate can act on a vault's behalf for an entire wallet
+     * @notice Check if a delegate can act on a from's behalf for an entire wallet
      * @param delegate The potential delegate address
-     * @param vault The potential address who delegated rights
+     * @param from The potential address who delegated rights
      * @param rights Specific rights to check for, leave empty for full rights only
-     * @return valid Whether delegate is granted to act on the vault's behalf
+     * @return valid Whether delegate is granted to act on the from's behalf
      */
-    function checkDelegateForAll(address delegate, address vault, bytes32 rights) external view returns (bool);
+    function checkDelegateForAll(address delegate, address from, bytes32 rights) external view returns (bool);
 
     /**
-     * @notice Check if a delegate can act on a vault's behalf for a specific contract
+     * @notice Check if a delegate can act on a from's behalf for a specific contract
      * @param delegate The delegated address to check
      * @param contract_ The specific contract address being checked
-     * @param vault The cold wallet who issued the delegation
+     * @param from The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
-     * @return valid Whether delegate is granted to act on vault's behalf for entire wallet or that specific contract
+     * @return valid Whether delegate is granted to act on from's behalf for entire wallet or that specific contract
      */
-    function checkDelegateForContract(address delegate, address vault, address contract_, bytes32 rights) external view returns (bool);
+    function checkDelegateForContract(address delegate, address from, address contract_, bytes32 rights) external view returns (bool);
 
     /**
-     * @notice Check if a delegate can act on a vault's behalf for a specific token
+     * @notice Check if a delegate can act on a from's behalf for a specific token
      * @param delegate The delegated address to check
      * @param contract_ The specific contract address being checked
      * @param tokenId The token id for the token to delegating
-     * @param vault The wallet that issued the delegation
+     * @param from The wallet that issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
-     * @return valid Whether delegate is granted to act on vault's behalf for entire wallet, that contract, or that specific tokenId
+     * @return valid Whether delegate is granted to act on from's behalf for entire wallet, that contract, or that specific tokenId
      */
-    function checkDelegateForERC721(address delegate, address vault, address contract_, uint256 tokenId, bytes32 rights) external view returns (bool);
+    function checkDelegateForERC721(address delegate, address from, address contract_, uint256 tokenId, bytes32 rights) external view returns (bool);
 
     /**
      * @notice Returns the amount of ERC20 tokens the delegate is granted rights to act on the behalf of
      * @param delegate The delegated address to check
      * @param contract_ The address of the token contract
-     * @param vault The cold wallet who issued the delegation
+     * @param from The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return balance The delegated balance, which will be 0 if the delegation does not exist
      */
-    function checkDelegateForERC20(address delegate, address vault, address contract_, bytes32 rights) external view returns (uint256);
+    function checkDelegateForERC20(address delegate, address from, address contract_, bytes32 rights) external view returns (uint256);
 
     /**
      * @notice Returns the amount of a ERC1155 tokens the delegate is granted rights to act on the behalf of
      * @param delegate The delegated address to check
      * @param contract_ The address of the token contract
      * @param tokenId The token id to check the delegated amount of
-     * @param vault The cold wallet who issued the delegation
+     * @param from The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return balance The delegated balance, which will be 0 if the delegation does not exist
      */
-    function checkDelegateForERC1155(address delegate, address vault, address contract_, uint256 tokenId, bytes32 rights) external view returns (uint256);
+    function checkDelegateForERC1155(address delegate, address from, address contract_, uint256 tokenId, bytes32 rights) external view returns (uint256);
 
     /**
      * ----------- ENUMERATIONS -----------

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -5,7 +5,7 @@ pragma solidity >=0.8.13;
  * @title IDelegateRegistry
  * @custom:version 2.0
  * @custom:author foobar (0xfoobar)
- * @notice A standalone immutable registry storing delegated permissions from one wallet to another
+ * @notice A standalone immutable registry storing delegated permissions from one address to another
  */
 interface IDelegateRegistry {
     /// @notice Delegation type
@@ -112,54 +112,54 @@ interface IDelegateRegistry {
 
     /**
      * @notice Check if a delegate can act on a from's behalf for an entire wallet
-     * @param delegate The potential delegate address
+     * @param to The potential delegate address
      * @param from The potential address who delegated rights
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return valid Whether delegate is granted to act on the from's behalf
      */
-    function checkDelegateForAll(address delegate, address from, bytes32 rights) external view returns (bool);
+    function checkDelegateForAll(address to, address from, bytes32 rights) external view returns (bool);
 
     /**
      * @notice Check if a delegate can act on a from's behalf for a specific contract
-     * @param delegate The delegated address to check
+     * @param to The delegated address to check
      * @param contract_ The specific contract address being checked
      * @param from The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return valid Whether delegate is granted to act on from's behalf for entire wallet or that specific contract
      */
-    function checkDelegateForContract(address delegate, address from, address contract_, bytes32 rights) external view returns (bool);
+    function checkDelegateForContract(address to, address from, address contract_, bytes32 rights) external view returns (bool);
 
     /**
      * @notice Check if a delegate can act on a from's behalf for a specific token
-     * @param delegate The delegated address to check
+     * @param to The delegated address to check
      * @param contract_ The specific contract address being checked
      * @param tokenId The token id for the token to delegating
      * @param from The wallet that issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return valid Whether delegate is granted to act on from's behalf for entire wallet, that contract, or that specific tokenId
      */
-    function checkDelegateForERC721(address delegate, address from, address contract_, uint256 tokenId, bytes32 rights) external view returns (bool);
+    function checkDelegateForERC721(address to, address from, address contract_, uint256 tokenId, bytes32 rights) external view returns (bool);
 
     /**
      * @notice Returns the amount of ERC20 tokens the delegate is granted rights to act on the behalf of
-     * @param delegate The delegated address to check
+     * @param to The delegated address to check
      * @param contract_ The address of the token contract
      * @param from The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return balance The delegated balance, which will be 0 if the delegation does not exist
      */
-    function checkDelegateForERC20(address delegate, address from, address contract_, bytes32 rights) external view returns (uint256);
+    function checkDelegateForERC20(address to, address from, address contract_, bytes32 rights) external view returns (uint256);
 
     /**
      * @notice Returns the amount of a ERC1155 tokens the delegate is granted rights to act on the behalf of
-     * @param delegate The delegated address to check
+     * @param to The delegated address to check
      * @param contract_ The address of the token contract
      * @param tokenId The token id to check the delegated amount of
      * @param from The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return balance The delegated balance, which will be 0 if the delegation does not exist
      */
-    function checkDelegateForERC1155(address delegate, address from, address contract_, uint256 tokenId, bytes32 rights) external view returns (uint256);
+    function checkDelegateForERC1155(address to, address from, address contract_, uint256 tokenId, bytes32 rights) external view returns (uint256);
 
     /**
      * ----------- ENUMERATIONS -----------

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -29,24 +29,24 @@ interface IDelegateRegistry {
         uint256 amount;
     }
 
-    /// @notice Emitted when a user delegates rights for their entire wallet
+    /// @notice Emitted when an address delegates rights for their entire wallet
     event DelegateAll(address indexed vault, address indexed delegate, bytes32 rights, bool enable);
 
-    /// @notice Emitted when a user delegates rights for a specific contract
+    /// @notice Emitted when an address delegates rights for a specific contract
     event DelegateContract(address indexed vault, address indexed delegate, address indexed contract_, bytes32 rights, bool enable);
 
-    /// @notice Emitted when a user delegates rights for a specific ERC721 token
+    /// @notice Emitted when an address delegates rights for a specific ERC721 token
     event DelegateERC721(address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, bytes32 rights, bool enable);
 
-    /// @notice Emitted when a user delegates rights for a specific amount of ERC20 tokens
+    /// @notice Emitted when an address delegates rights for a specific amount of ERC20 tokens
     event DelegateERC20(address indexed vault, address indexed delegate, address indexed contract_, uint256 amount, bytes32 rights, bool enable);
 
-    /// @notice Emitted when a user delegates rights for a specific amount of ERC1155 tokens
+    /// @notice Emitted when an address delegates rights for a specific amount of ERC1155 tokens
     event DelegateERC1155(
         address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable
     );
 
-    /// @notice Emitted if multicall calldata is malformed
+    /// @notice Thrown if multicall calldata is malformed
     error MulticallFailed();
 
     /**
@@ -54,53 +54,55 @@ interface IDelegateRegistry {
      */
 
     /**
-     * @notice Call multiple registry functions at once with multicall
+     * @notice Call multiple functions in the current contract and return the data from all of them if they all succeed
+     * @param data The encoded function data for each of the calls to make to this contract
+     * @return results The results from each of the calls passed in via data
      */
     function multicall(bytes[] calldata data) external returns (bytes[] memory results);
 
     /**
-     * @notice Allow the delegate to act on your behalf for all contracts
-     * @param delegate The hotwallet to act on your behalf
+     * @notice Allow the delegate to act on behalf of `msg.sender` for all contracts
+     * @param delegate The address to act as delegate
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
     function delegateAll(address delegate, bytes32 rights, bool enable) external;
 
     /**
-     * @notice Allow the delegate to act on your behalf for a specific contract
-     * @param delegate The hotwallet to act on your behalf
-     * @param contract_ The address for the contract you're delegating
+     * @notice Allow the delegate to act on behalf of `msg.sender` for a specific contract
+     * @param delegate The address to act as delegate
+     * @param contract_ The contract whose rights are being delegated
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
     function delegateContract(address delegate, address contract_, bytes32 rights, bool enable) external;
 
     /**
-     * @notice Allow the delegate to act on your behalf for a specific ERC721 token
-     * @param delegate The hotwallet to act on your behalf
-     * @param contract_ The address for the contract you're delegating
-     * @param tokenId The token id for the token you're delegating
+     * @notice Allow the delegate to act on behalf of `msg.sender` for a specific ERC721 token
+     * @param delegate The address to act as delegate
+     * @param contract_ The contract whose rights are being delegated
+     * @param tokenId The token id to delegate
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
     function delegateERC721(address delegate, address contract_, uint256 tokenId, bytes32 rights, bool enable) external;
 
     /**
-     * @notice Allow the delegate to act on your behalf for a specific amount of ERC20 tokens
-     * @param delegate The hotwallet to act on your behalf
+     * @notice Allow the delegate to act on behalf of `msg.sender` for a specific amount of ERC20 tokens
+     * @param delegate The address to act as delegate
      * @param contract_ The address for the fungible token contract
-     * @param amount The amount you want to delegate
+     * @param amount The amount to delegate
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
     function delegateERC20(address delegate, address contract_, uint256 amount, bytes32 rights, bool enable) external;
 
     /**
-     * @notice Allow the delegate to act on your behalf for a specific amount of ERC1155 tokens
-     * @param delegate The hotwallet to act on your behalf
+     * @notice Allow the delegate to act on behalf of `msg.sender` for a specific amount of ERC1155 tokens
+     * @param delegate The address to act as delegate
      * @param contract_ The address of the contract that holds the token
-     * @param tokenId, the id of the token you are delegating the amount of
-     * @param amount The amount you want to delegate
+     * @param tokenId The token id to delegate
+     * @param amount The amount of that token id to delegate
      * @param rights The rights granted to the delegate, leave empty for full rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
      */
@@ -112,8 +114,8 @@ interface IDelegateRegistry {
 
     /**
      * @notice Check if a delegate can act on a vault's behalf for an entire wallet
-     * @param delegate The hotwallet to act on your behalf
-     * @param vault The cold wallet who issued the delegation
+     * @param delegate The potential delegate address
+     * @param vault The potential address who delegated rights
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return valid Whether delegate is granted to act on the vault's behalf
      */
@@ -121,8 +123,8 @@ interface IDelegateRegistry {
 
     /**
      * @notice Check if a delegate can act on a vault's behalf for a specific contract
-     * @param delegate The hotwallet to act on your behalf
-     * @param contract_ The address for the contract you're delegating
+     * @param delegate The delegated address to check
+     * @param contract_ The specific contract address being checked
      * @param vault The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return valid Whether delegate is granted to act on vault's behalf for entire wallet or that specific contract
@@ -131,10 +133,10 @@ interface IDelegateRegistry {
 
     /**
      * @notice Check if a delegate can act on a vault's behalf for a specific token
-     * @param delegate The hotwallet to act on your behalf
-     * @param contract_ The address for the contract you're delegating
-     * @param tokenId The token id for the token you're delegating
-     * @param vault The cold wallet who issued the delegation
+     * @param delegate The delegated address to check
+     * @param contract_ The specific contract address being checked
+     * @param tokenId The token id for the token to delegating
+     * @param vault The wallet that issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return valid Whether delegate is granted to act on vault's behalf for entire wallet, that contract, or that specific tokenId
      */
@@ -142,7 +144,7 @@ interface IDelegateRegistry {
 
     /**
      * @notice Returns the amount of ERC20 tokens the delegate is granted rights to act on the behalf of
-     * @param delegate The hotwallet to act on your behalf
+     * @param delegate The delegated address to check
      * @param contract_ The address of the token contract
      * @param vault The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
@@ -152,9 +154,9 @@ interface IDelegateRegistry {
 
     /**
      * @notice Returns the amount of a ERC1155 tokens the delegate is granted rights to act on the behalf of
-     * @param delegate The hotwallet to act on your behalf
+     * @param delegate The delegated address to check
      * @param contract_ The address of the token contract
-     * @param tokenId the token id for the token you're delegating the amount of
+     * @param tokenId The token id to check the delegated amount of
      * @param vault The cold wallet who issued the delegation
      * @param rights Specific rights to check for, leave empty for full rights only
      * @return balance The delegated balance, which will be 0 if the delegation does not exist
@@ -170,28 +172,28 @@ interface IDelegateRegistry {
      * @param delegate The delegate to retrieve delegations for
      * @return delegations Array of Delegation structs
      */
-    function getDelegationsForDelegate(address delegate) external view returns (Delegation[] memory delegations);
+    function getIncomingDelegations(address delegate) external view returns (Delegation[] memory delegations);
 
     /**
      * @notice Returns all enabled delegations a vault has granted
      * @param vault The vault to retrieve delegations for
      * @return delegations Array of Delegation structs
      */
-    function getDelegationsForVault(address vault) external view returns (Delegation[] memory delegations);
+    function getOutgoingDelegations(address vault) external view returns (Delegation[] memory delegations);
 
     /**
      * @notice Returns all hashes associated with enabled delegations a delegate has been granted
      * @param delegate The delegate to retrieve the delegation hashes for
      * @return delegationHashes Array of delegation hashes
      */
-    function getDelegationHashesForDelegate(address delegate) external view returns (bytes32[] memory delegationHashes);
+    function getIncomingDelegationHashes(address delegate) external view returns (bytes32[] memory delegationHashes);
 
     /**
      * @notice Returns all hashes associated with enabled delegations a vault has granted
      * @param vault The vault to retrieve the delegation hashes for
      * @return delegationHashes Array of delegation hashes
      */
-    function getDelegationHashesForVault(address vault) external view returns (bytes32[] memory delegationHashes);
+    function getOutgoingDelegationHashes(address vault) external view returns (bytes32[] memory delegationHashes);
 
     /**
      * @notice Returns the delegations for a given array of delegation hashes

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -9,9 +9,8 @@ pragma solidity >=0.8.13;
  */
 interface IDelegateRegistry {
     /// @notice Delegation type
-    enum DelegationType
-    // NONE,
-    {
+    enum DelegationType {
+        NONE,
         ALL,
         CONTRACT,
         ERC721,
@@ -31,19 +30,19 @@ interface IDelegateRegistry {
     }
 
     /// @notice Emitted when a user delegates rights for their entire wallet
-    event AllDelegated(address indexed vault, address indexed delegate, bytes32 rights, bool enable);
+    event DelegateAll(address indexed vault, address indexed delegate, bytes32 rights, bool enable);
 
     /// @notice Emitted when a user delegates rights for a specific contract
-    event ContractDelegated(address indexed vault, address indexed delegate, address indexed contract_, bytes32 rights, bool enable);
+    event DelegateContract(address indexed vault, address indexed delegate, address indexed contract_, bytes32 rights, bool enable);
 
     /// @notice Emitted when a user delegates rights for a specific ERC721 token
-    event ERC721Delegated(address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, bytes32 rights, bool enable);
+    event DelegateERC721(address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, bytes32 rights, bool enable);
 
     /// @notice Emitted when a user delegates rights for a specific amount of ERC20 tokens
-    event ERC20Delegated(address indexed vault, address indexed delegate, address indexed contract_, uint256 amount, bytes32 rights, bool enable);
+    event DelegateERC20(address indexed vault, address indexed delegate, address indexed contract_, uint256 amount, bytes32 rights, bool enable);
 
     /// @notice Emitted when a user delegates rights for a specific amount of ERC1155 tokens
-    event ERC1155Delegated(
+    event DelegateERC1155(
         address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable
     );
 

--- a/src/tools/RegistryHarness.sol
+++ b/src/tools/RegistryHarness.sol
@@ -9,12 +9,12 @@ contract RegistryHarness is DelegateRegistry {
         return _delegations[hash];
     }
 
-    function exposed_vaultDelegationHashes(address vault) external view returns (bytes32[] memory) {
-        return _vaultDelegationHashes[vault];
+    function exposed_outgoingDelegationHashes(address vault) external view returns (bytes32[] memory) {
+        return _outgoingDelegationHashes[vault];
     }
 
-    function exposed_delegateDelegationHashes(address delegate) external view returns (bytes32[] memory) {
-        return _delegateDelegationHashes[delegate];
+    function exposed_incomingDelegationHashes(address delegate) external view returns (bytes32[] memory) {
+        return _incomingDelegationHashes[delegate];
     }
 
     function exposed_computeDelegationHashForAll(address delegate, bytes32 rights, address vault) external pure returns (bytes32) {

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -103,10 +103,10 @@ contract DelegateRegistryTest is Test {
         // Read
         IDelegateRegistry.Delegation[] memory info = reg.getOutgoingDelegations(vault);
         assertEq(info.length, 2);
-        assertEq(info[0].vault, vault);
-        assertEq(info[0].delegate, delegate0);
-        assertEq(info[1].vault, vault);
-        assertEq(info[1].delegate, delegate1);
+        assertEq(info[0].from, vault);
+        assertEq(info[0].to, delegate0);
+        assertEq(info[1].from, vault);
+        assertEq(info[1].to, delegate1);
         // Remove
         reg.delegateAll(delegate0, rights, false);
         info = reg.getOutgoingDelegations(vault);
@@ -123,10 +123,10 @@ contract DelegateRegistryTest is Test {
 
         IDelegateRegistry.Delegation[] memory delegations = reg.getOutgoingDelegations(vault);
         assertEq(delegations.length, 2);
-        assertEq(delegations[0].vault, vault);
-        assertEq(delegations[1].vault, vault);
-        assertEq(delegations[0].delegate, delegate0);
-        assertEq(delegations[1].delegate, delegate1);
+        assertEq(delegations[0].from, vault);
+        assertEq(delegations[1].from, vault);
+        assertEq(delegations[0].to, delegate0);
+        assertEq(delegations[1].to, delegate1);
         assertTrue(delegations[0].type_ == IDelegateRegistry.DelegationType.ALL);
         assertTrue(delegations[1].type_ == IDelegateRegistry.DelegationType.ALL);
     }

--- a/test/DelegationRegistry.t.sol
+++ b/test/DelegationRegistry.t.sol
@@ -101,7 +101,7 @@ contract DelegateRegistryTest is Test {
         reg.delegateAll(delegate0, rights, true);
         reg.delegateAll(delegate1, rights, true);
         // Read
-        IDelegateRegistry.Delegation[] memory info = reg.getDelegationsForVault(vault);
+        IDelegateRegistry.Delegation[] memory info = reg.getOutgoingDelegations(vault);
         assertEq(info.length, 2);
         assertEq(info[0].vault, vault);
         assertEq(info[0].delegate, delegate0);
@@ -109,7 +109,7 @@ contract DelegateRegistryTest is Test {
         assertEq(info[1].delegate, delegate1);
         // Remove
         reg.delegateAll(delegate0, rights, false);
-        info = reg.getDelegationsForVault(vault);
+        info = reg.getOutgoingDelegations(vault);
         assertEq(info.length, 1);
     }
 
@@ -121,7 +121,7 @@ contract DelegateRegistryTest is Test {
         batchData[1] = abi.encodeWithSelector(IDelegateRegistry.delegateAll.selector, delegate1, "", true);
         reg.multicall(batchData);
 
-        IDelegateRegistry.Delegation[] memory delegations = reg.getDelegationsForVault(vault);
+        IDelegateRegistry.Delegation[] memory delegations = reg.getOutgoingDelegations(vault);
         assertEq(delegations.length, 2);
         assertEq(delegations[0].vault, vault);
         assertEq(delegations[1].vault, vault);
@@ -175,23 +175,23 @@ contract DelegateRegistryTest is Test {
         // vault0 revokes all three tiers for delegate0, check incremental decrease in delegate enumerations
         changePrank(vault0);
         // check six in total, three from vault0 and three from vault1
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 10);
-        assertEq(reg.getDelegationHashesForDelegate(delegate0).length, 10);
+        assertEq(reg.getIncomingDelegations(delegate0).length, 10);
+        assertEq(reg.getIncomingDelegationHashes(delegate0).length, 10);
         reg.delegateAll(delegate0, rights, false);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 9);
-        assertEq(reg.getDelegationHashesForDelegate(delegate0).length, 9);
+        assertEq(reg.getIncomingDelegations(delegate0).length, 9);
+        assertEq(reg.getIncomingDelegationHashes(delegate0).length, 9);
         reg.delegateContract(delegate0, contract0, rights, false);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 8);
-        assertEq(reg.getDelegationHashesForDelegate(delegate0).length, 8);
+        assertEq(reg.getIncomingDelegations(delegate0).length, 8);
+        assertEq(reg.getIncomingDelegationHashes(delegate0).length, 8);
         reg.delegateERC721(delegate0, contract0, tokenId0, rights, false);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 7);
-        assertEq(reg.getDelegationHashesForDelegate(delegate0).length, 7);
+        assertEq(reg.getIncomingDelegations(delegate0).length, 7);
+        assertEq(reg.getIncomingDelegationHashes(delegate0).length, 7);
         reg.delegateERC20(delegate0, contract0, amount0, rights, false);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 6);
-        assertEq(reg.getDelegationHashesForDelegate(delegate0).length, 6);
+        assertEq(reg.getIncomingDelegations(delegate0).length, 6);
+        assertEq(reg.getIncomingDelegationHashes(delegate0).length, 6);
         reg.delegateERC1155(delegate0, contract0, tokenId0, amount0, rights, false);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 5);
-        assertEq(reg.getDelegationHashesForDelegate(delegate0).length, 5);
+        assertEq(reg.getIncomingDelegations(delegate0).length, 5);
+        assertEq(reg.getIncomingDelegationHashes(delegate0).length, 5);
 
         // vault0 re-delegates to delegate0
         changePrank(vault0);
@@ -200,10 +200,10 @@ contract DelegateRegistryTest is Test {
         reg.delegateERC721(delegate0, contract0, tokenId0, rights, true);
         reg.delegateERC20(delegate0, contract0, amount0, rights, true);
         reg.delegateERC1155(delegate0, contract0, tokenId0, amount0, rights, true);
-        assertEq(reg.getDelegationsForDelegate(delegate0).length, 10);
-        assertEq(reg.getDelegationsForDelegate(delegate1).length, 5);
-        assertEq(reg.getDelegationHashesForDelegate(delegate0).length, 10);
-        assertEq(reg.getDelegationHashesForDelegate(delegate1).length, 5);
+        assertEq(reg.getIncomingDelegations(delegate0).length, 10);
+        assertEq(reg.getIncomingDelegations(delegate1).length, 5);
+        assertEq(reg.getIncomingDelegationHashes(delegate0).length, 10);
+        assertEq(reg.getIncomingDelegationHashes(delegate1).length, 5);
     }
 
     function testVaultEnumerations(address vault, address delegate0, address delegate1, address contract0, address contract1, uint256 tokenId, uint256 amount)
@@ -223,7 +223,7 @@ contract DelegateRegistryTest is Test {
 
         // Read
         IDelegateRegistry.Delegation[] memory vaultDelegations;
-        vaultDelegations = reg.getDelegationsForVault(vault);
+        vaultDelegations = reg.getOutgoingDelegations(vault);
         assertEq(vaultDelegations.length, 6);
         assertTrue(vaultDelegations[1].type_ == IDelegateRegistry.DelegationType.CONTRACT);
     }
@@ -245,14 +245,14 @@ contract DelegateRegistryTest is Test {
     function testGetDelegationsGas() public {
         uint256 delegationsLimit = 2600; // Actual limit is x5
         _createUniqueDelegations(0, delegationsLimit);
-        IDelegateRegistry.Delegation[] memory vaultDelegations = reg.getDelegationsForVault(address(this));
+        IDelegateRegistry.Delegation[] memory vaultDelegations = reg.getOutgoingDelegations(address(this));
         assertEq(vaultDelegations.length, 5 * delegationsLimit);
     }
 
     function testGetDelegationHashesGas() public {
         uint256 hashesLimit = 20800; // Actual limit is x5
         _createUniqueDelegations(0, hashesLimit);
-        bytes32[] memory vaultDelegationHashes = reg.getDelegationHashesForVault(address(this));
+        bytes32[] memory vaultDelegationHashes = reg.getOutgoingDelegationHashes(address(this));
         assertEq(vaultDelegationHashes.length, 5 * hashesLimit);
     }
 }

--- a/test/GasBenchmark.t.sol
+++ b/test/GasBenchmark.t.sol
@@ -16,8 +16,8 @@ contract GasBenchmark is Test {
         delegations = new IRegistry.Delegation[](5);
         delegations[0] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.ALL,
-            delegate: address(bytes20(keccak256(abi.encode(seed, "ALL", "delegate")))),
-            vault: address(0),
+            to: address(bytes20(keccak256(abi.encode(seed, "ALL", "delegate")))),
+            from: address(0),
             rights: "",
             contract_: address(0),
             tokenId: 0,
@@ -25,8 +25,8 @@ contract GasBenchmark is Test {
         });
         delegations[1] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.CONTRACT,
-            delegate: address(bytes20(keccak256(abi.encode(seed, "CONTRACT", "delegate")))),
-            vault: address(0),
+            to: address(bytes20(keccak256(abi.encode(seed, "CONTRACT", "delegate")))),
+            from: address(0),
             rights: "",
             contract_: address(bytes20(keccak256(abi.encode(seed, "CONTRACT", "contract_")))),
             tokenId: 0,
@@ -34,8 +34,8 @@ contract GasBenchmark is Test {
         });
         delegations[2] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.ERC721,
-            delegate: address(bytes20(keccak256(abi.encode(seed, "ERC721", "delegate")))),
-            vault: address(0),
+            to: address(bytes20(keccak256(abi.encode(seed, "ERC721", "delegate")))),
+            from: address(0),
             rights: "",
             contract_: address(bytes20(keccak256(abi.encode(seed, "ERC721", "contract_")))),
             tokenId: uint256(keccak256(abi.encode(seed, "ERC721", "tokenId"))),
@@ -43,8 +43,8 @@ contract GasBenchmark is Test {
         });
         delegations[3] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.ERC20,
-            delegate: address(bytes20(keccak256(abi.encode(seed, "ERC20", "delegate")))),
-            vault: address(0),
+            to: address(bytes20(keccak256(abi.encode(seed, "ERC20", "delegate")))),
+            from: address(0),
             rights: "",
             contract_: address(bytes20(keccak256(abi.encode(seed, "ERC20", "contract_")))),
             tokenId: 0,
@@ -52,8 +52,8 @@ contract GasBenchmark is Test {
         });
         delegations[4] = IRegistry.Delegation({
             type_: IRegistry.DelegationType.ERC1155,
-            delegate: address(bytes20(keccak256(abi.encode(seed, "ERC1155", "delegate")))),
-            vault: address(0),
+            to: address(bytes20(keccak256(abi.encode(seed, "ERC1155", "delegate")))),
+            from: address(0),
             rights: "",
             contract_: address(bytes20(keccak256(abi.encode(seed, "ERC1155", "contract_")))),
             tokenId: uint256(keccak256(abi.encode(seed, "ERC1155", "tokenId"))),
@@ -66,36 +66,36 @@ contract GasBenchmark is Test {
         // Benchmark delegate all and check all
         registry = new Registry();
         IRegistry.Delegation[] memory delegations = _createDelegations(keccak256(abi.encode(seed, "delegations")));
-        registry.delegateAll(delegations[0].delegate, delegations[0].rights, true);
-        registry.checkDelegateForAll(delegations[0].delegate, vault, delegations[0].rights);
+        registry.delegateAll(delegations[0].to, delegations[0].rights, true);
+        registry.checkDelegateForAll(delegations[0].to, vault, delegations[0].rights);
         // Benchmark delegate contract and check contract
         registry = new Registry();
-        registry.delegateContract(delegations[1].delegate, delegations[1].contract_, delegations[1].rights, true);
-        registry.checkDelegateForContract(delegations[1].delegate, vault, delegations[1].contract_, delegations[1].rights);
+        registry.delegateContract(delegations[1].to, delegations[1].contract_, delegations[1].rights, true);
+        registry.checkDelegateForContract(delegations[1].to, vault, delegations[1].contract_, delegations[1].rights);
         // Benchmark delegate erc721 and check erc721
         registry = new Registry();
-        registry.delegateERC721(delegations[2].delegate, delegations[2].contract_, delegations[2].tokenId, delegations[2].rights, true);
-        registry.checkDelegateForERC721(delegations[2].delegate, vault, delegations[2].contract_, delegations[2].tokenId, delegations[2].rights);
+        registry.delegateERC721(delegations[2].to, delegations[2].contract_, delegations[2].tokenId, delegations[2].rights, true);
+        registry.checkDelegateForERC721(delegations[2].to, vault, delegations[2].contract_, delegations[2].tokenId, delegations[2].rights);
         // Benchmark delegate erc20 and check erc20
         registry = new Registry();
-        registry.delegateERC20(delegations[3].delegate, delegations[3].contract_, delegations[3].amount, delegations[3].rights, true);
-        registry.checkDelegateForERC20(delegations[3].delegate, vault, delegations[3].contract_, delegations[3].rights);
+        registry.delegateERC20(delegations[3].to, delegations[3].contract_, delegations[3].amount, delegations[3].rights, true);
+        registry.checkDelegateForERC20(delegations[3].to, vault, delegations[3].contract_, delegations[3].rights);
         // Benchmark delegate erc1155 and check erc20
         registry = new Registry();
-        registry.delegateERC1155(delegations[4].delegate, delegations[4].contract_, delegations[4].tokenId, delegations[4].amount, delegations[4].rights, true);
-        registry.checkDelegateForERC1155(delegations[4].delegate, vault, delegations[4].contract_, delegations[4].tokenId, delegations[4].rights);
+        registry.delegateERC1155(delegations[4].to, delegations[4].contract_, delegations[4].tokenId, delegations[4].amount, delegations[4].rights, true);
+        registry.checkDelegateForERC1155(delegations[4].to, vault, delegations[4].contract_, delegations[4].tokenId, delegations[4].rights);
         // Benchmark multicall
         registry = new Registry();
         IRegistry.Delegation[] memory multicallDelegations = new IRegistry.Delegation[](5);
         multicallDelegations = _createDelegations(keccak256(abi.encode(seed, "multicall")));
         bytes[] memory data = new bytes[](5);
-        data[0] = abi.encodeWithSelector(IRegistry.delegateAll.selector, multicallDelegations[0].delegate, multicallDelegations[0].rights, true);
+        data[0] = abi.encodeWithSelector(IRegistry.delegateAll.selector, multicallDelegations[0].to, multicallDelegations[0].rights, true);
         data[1] = abi.encodeWithSelector(
-            IRegistry.delegateContract.selector, multicallDelegations[1].delegate, multicallDelegations[1].contract_, multicallDelegations[1].rights, true
+            IRegistry.delegateContract.selector, multicallDelegations[1].to, multicallDelegations[1].contract_, multicallDelegations[1].rights, true
         );
         data[2] = abi.encodeWithSelector(
             IRegistry.delegateERC721.selector,
-            multicallDelegations[2].delegate,
+            multicallDelegations[2].to,
             multicallDelegations[2].contract_,
             multicallDelegations[2].tokenId,
             multicallDelegations[2].rights,
@@ -103,7 +103,7 @@ contract GasBenchmark is Test {
         );
         data[3] = abi.encodeWithSelector(
             IRegistry.delegateERC20.selector,
-            multicallDelegations[3].delegate,
+            multicallDelegations[3].to,
             multicallDelegations[3].contract_,
             multicallDelegations[3].amount,
             multicallDelegations[3].rights,
@@ -111,7 +111,7 @@ contract GasBenchmark is Test {
         );
         data[4] = abi.encodeWithSelector(
             IRegistry.delegateERC1155.selector,
-            multicallDelegations[4].delegate,
+            multicallDelegations[4].to,
             multicallDelegations[4].contract_,
             multicallDelegations[4].tokenId,
             multicallDelegations[4].amount,

--- a/test/RegistrySingularIntegrations.t.sol
+++ b/test/RegistrySingularIntegrations.t.sol
@@ -605,16 +605,16 @@ contract DelegateSingularIntegrations is Test {
     function _checkDelegation(IRegistry.Delegation memory delegation) internal {
         if (_enable) {
             assertEq(uint256(delegation.type_), uint256(_type));
-            assertEq(delegation.delegate, _delegate);
-            assertEq(delegation.vault, _vault);
+            assertEq(delegation.to, _delegate);
+            assertEq(delegation.from, _vault);
             assertEq(delegation.rights, _rights);
             assertEq(delegation.contract_, _contract);
             assertEq(delegation.tokenId, _tokenId);
             assertEq(delegation.amount, _amount);
         } else {
             assertEq(uint256(delegation.type_), uint256(IRegistry.DelegationType.NONE));
-            assertEq(delegation.delegate, address(0));
-            assertEq(uint160(delegation.vault), uint160(0));
+            assertEq(delegation.to, address(0));
+            assertEq(uint160(delegation.from), uint160(0));
             assertEq(delegation.rights, "");
             assertEq(delegation.contract_, address(0));
             assertEq(delegation.tokenId, 0);

--- a/test/RegistrySingularIntegrations.t.sol
+++ b/test/RegistrySingularIntegrations.t.sol
@@ -478,9 +478,7 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(
-                registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault)
-            );
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);

--- a/test/RegistrySingularIntegrations.t.sol
+++ b/test/RegistrySingularIntegrations.t.sol
@@ -614,9 +614,9 @@ contract DelegateSingularIntegrations is Test {
             assertEq(delegation.tokenId, _tokenId);
             assertEq(delegation.amount, _amount);
         } else {
-            assertEq(uint256(delegation.type_), uint256(_type));
+            assertEq(uint256(delegation.type_), uint256(IRegistry.DelegationType.NONE));
             assertEq(delegation.delegate, address(0));
-            assertLe(uint160(delegation.vault), uint160(address(1)));
+            assertEq(uint160(delegation.vault), uint160(0));
             assertEq(delegation.rights, "");
             assertEq(delegation.contract_, address(0));
             assertEq(delegation.tokenId, 0);

--- a/test/RegistrySingularIntegrations.t.sol
+++ b/test/RegistrySingularIntegrations.t.sol
@@ -155,15 +155,15 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadAll() internal {
-        // Check outcomes of getDelegationHashesForDelegate
-        assertEq(registry.getDelegationHashesForDelegate(_delegate).length == 1, _enable);
+        // Check outcomes of getIncomingDelegationHashes
+        assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getDelegationHashesForDelegate(_delegate)[0], harness.exposed_computeDelegationHashForAll(_delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeDelegationHashForAll(_delegate, _rights, _vault));
         }
-        // Check outcomes of getDelegationHashesForVault
-        assertEq(registry.getDelegationHashesForVault(_vault).length == 1, _enable);
+        // Check outcomes of getOutgoingDelegationHashes
+        assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getDelegationHashesForVault(_vault)[0], harness.exposed_computeDelegationHashForAll(_delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeDelegationHashForAll(_delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
@@ -266,17 +266,17 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadContract() internal {
-        // Check outcomes of getDelegationHashesForDelegate
-        assertEq(registry.getDelegationHashesForDelegate(_delegate).length == 1, _enable);
+        // Check outcomes of getIncomingDelegationHashes
+        assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
             assertEq(
-                registry.getDelegationHashesForDelegate(_delegate)[0], harness.exposed_computeDelegationHashForContract(_contract, _delegate, _rights, _vault)
+                registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeDelegationHashForContract(_contract, _delegate, _rights, _vault)
             );
         }
-        // Check outcomes of getDelegationHashesForVault
-        assertEq(registry.getDelegationHashesForVault(_vault).length == 1, _enable);
+        // Check outcomes of getOutgoingDelegationHashes
+        assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getDelegationHashesForVault(_vault)[0], harness.exposed_computeDelegationHashForContract(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeDelegationHashForContract(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
@@ -368,19 +368,19 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadERC721() internal {
-        // Check outcomes of getDelegationHashesForDelegate
-        assertEq(registry.getDelegationHashesForDelegate(_delegate).length == 1, _enable);
+        // Check outcomes of getIncomingDelegationHashes
+        assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
             assertEq(
-                registry.getDelegationHashesForDelegate(_delegate)[0],
+                registry.getIncomingDelegationHashes(_delegate)[0],
                 harness.exposed_computeDelegationHashForERC721(_contract, _delegate, _rights, _tokenId, _vault)
             );
         }
-        // Check outcomes of getDelegationHashesForVault
-        assertEq(registry.getDelegationHashesForVault(_vault).length == 1, _enable);
+        // Check outcomes of getOutgoingDelegationHashes
+        assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
             assertEq(
-                registry.getDelegationHashesForVault(_vault)[0], harness.exposed_computeDelegationHashForERC721(_contract, _delegate, _rights, _tokenId, _vault)
+                registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeDelegationHashForERC721(_contract, _delegate, _rights, _tokenId, _vault)
             );
         }
         // Check outcomes of getDelegationsFromHashes
@@ -475,17 +475,17 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadERC20() internal {
-        // Check outcomes of getDelegationHashesForDelegate
-        assertEq(registry.getDelegationHashesForDelegate(_delegate).length == 1, _enable);
+        // Check outcomes of getIncomingDelegationHashes
+        assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
             assertEq(
-                registry.getDelegationHashesForDelegate(_delegate)[0], harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault)
+                registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault)
             );
         }
-        // Check outcomes of getDelegationHashesForVault
-        assertEq(registry.getDelegationHashesForVault(_vault).length == 1, _enable);
+        // Check outcomes of getOutgoingDelegationHashes
+        assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getDelegationHashesForVault(_vault)[0], harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
@@ -581,19 +581,19 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadERC1155() internal {
-        // Check outcomes of getDelegationHashesForDelegate
-        assertEq(registry.getDelegationHashesForDelegate(_delegate).length == 1, _enable);
+        // Check outcomes of getIncomingDelegationHashes
+        assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
             assertEq(
-                registry.getDelegationHashesForDelegate(_delegate)[0],
+                registry.getIncomingDelegationHashes(_delegate)[0],
                 harness.exposed_computeDelegationHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault)
             );
         }
-        // Check outcomes of getDelegationHashesForVault
-        assertEq(registry.getDelegationHashesForVault(_vault).length == 1, _enable);
+        // Check outcomes of getOutgoingDelegationHashes
+        assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
             assertEq(
-                registry.getDelegationHashesForVault(_vault)[0],
+                registry.getOutgoingDelegationHashes(_vault)[0],
                 harness.exposed_computeDelegationHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault)
             );
         }
@@ -745,25 +745,25 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadCases() internal {
-        // getDelegationsForDelegate
-        assertEq(registry.getDelegationsForDelegate(_delegate).length == 1, _enable);
-        if (_enable) _checkDelegation(registry.getDelegationsForDelegate(_delegate)[0]);
-        assertEq(registry.getDelegationsForDelegate(_vault).length, 0);
-        assertEq(registry.getDelegationsForDelegate(_fVault).length, 0);
-        assertEq(registry.getDelegationsForDelegate(_fDelegate).length, 0);
-        // getDelegationsForVault
-        assertEq(registry.getDelegationsForVault(_vault).length == 1, _enable);
-        if (_enable) _checkDelegation(registry.getDelegationsForDelegate(_delegate)[0]);
-        assertEq(registry.getDelegationsForVault(_fVault).length, 0);
-        assertEq(registry.getDelegationsForVault(_delegate).length, 0);
-        assertEq(registry.getDelegationsForVault(_fDelegate).length, 0);
-        // getDelegationHashesForDelegate
-        assertEq(registry.getDelegationHashesForDelegate(_vault).length, 0);
-        assertEq(registry.getDelegationHashesForDelegate(_fVault).length, 0);
-        assertEq(registry.getDelegationHashesForDelegate(_fDelegate).length, 0);
-        // getDelegationHashesForVault
-        assertEq(registry.getDelegationHashesForVault(_fVault).length, 0);
-        assertEq(registry.getDelegationHashesForVault(_delegate).length, 0);
-        assertEq(registry.getDelegationHashesForVault(_fDelegate).length, 0);
+        // getIncomingDelegations
+        assertEq(registry.getIncomingDelegations(_delegate).length == 1, _enable);
+        if (_enable) _checkDelegation(registry.getIncomingDelegations(_delegate)[0]);
+        assertEq(registry.getIncomingDelegations(_vault).length, 0);
+        assertEq(registry.getIncomingDelegations(_fVault).length, 0);
+        assertEq(registry.getIncomingDelegations(_fDelegate).length, 0);
+        // getOutgoingDelegations
+        assertEq(registry.getOutgoingDelegations(_vault).length == 1, _enable);
+        if (_enable) _checkDelegation(registry.getIncomingDelegations(_delegate)[0]);
+        assertEq(registry.getOutgoingDelegations(_fVault).length, 0);
+        assertEq(registry.getOutgoingDelegations(_delegate).length, 0);
+        assertEq(registry.getOutgoingDelegations(_fDelegate).length, 0);
+        // getIncomingDelegationHashes
+        assertEq(registry.getIncomingDelegationHashes(_vault).length, 0);
+        assertEq(registry.getIncomingDelegationHashes(_fVault).length, 0);
+        assertEq(registry.getIncomingDelegationHashes(_fDelegate).length, 0);
+        // getOutgoingDelegationHashes
+        assertEq(registry.getOutgoingDelegationHashes(_fVault).length, 0);
+        assertEq(registry.getOutgoingDelegationHashes(_delegate).length, 0);
+        assertEq(registry.getOutgoingDelegationHashes(_fDelegate).length, 0);
     }
 }

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -97,10 +97,10 @@ contract RegistryUnitTests is Test {
         data[7] = abi.encodeWithSelector(registry.checkDelegateForERC721.selector, delegate, vault, contract_, tokenId, rights);
         data[8] = abi.encodeWithSelector(registry.checkDelegateForERC20.selector, delegate, vault, contract_, rights);
         data[9] = abi.encodeWithSelector(registry.checkDelegateForERC1155.selector, delegate, vault, contract_, tokenId, rights);
-        data[10] = abi.encodeWithSelector(registry.getDelegationsForDelegate.selector, delegate);
-        data[11] = abi.encodeWithSelector(registry.getDelegationsForVault.selector, vault);
-        data[12] = abi.encodeWithSelector(registry.getDelegationHashesForDelegate.selector, delegate);
-        data[13] = abi.encodeWithSelector(registry.getDelegationHashesForVault.selector, vault);
+        data[10] = abi.encodeWithSelector(registry.getIncomingDelegations.selector, delegate);
+        data[11] = abi.encodeWithSelector(registry.getOutgoingDelegations.selector, vault);
+        data[12] = abi.encodeWithSelector(registry.getIncomingDelegationHashes.selector, delegate);
+        data[13] = abi.encodeWithSelector(registry.getOutgoingDelegationHashes.selector, vault);
         bytes32[] memory hashes = new bytes32[](1);
         hashes[0] = hash;
         data[14] = abi.encodeWithSelector(registry.getDelegationsFromHashes.selector, hashes);

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -11,8 +11,8 @@ contract RegistryUnitTests is Test {
     Registry public registry;
 
     enum StoragePositions {
-        delegate,
-        vault,
+        to,
+        from,
         rights,
         contract_,
         tokenId,
@@ -342,8 +342,8 @@ contract RegistryUnitTests is Test {
 
     function _checkStorage(uint256 amount, address contract_, address delegate, bytes32 hash, bytes32 rights, uint256 tokenId, address vault) internal {
         assertEq(harness.exposed_delegations(hash).length, uint256(type(StoragePositions).max) + 1);
-        assertEq(address(uint160(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.delegate)]))), delegate);
-        assertEq(address(uint160(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.vault)]))), vault);
+        assertEq(address(uint160(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.to)]))), delegate);
+        assertEq(address(uint160(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.from)]))), vault);
         assertEq(harness.exposed_delegations(hash)[uint256(StoragePositions.rights)], rights);
         assertEq(address(uint160(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.contract_)]))), contract_);
         assertEq(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.tokenId)]), tokenId);

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -330,13 +330,13 @@ contract RegistryUnitTests is Test {
 
     function _checkHashes(address vault, address delegate, bytes32 hash, bool on) internal {
         if (on) {
-            assertEq(harness.exposed_vaultDelegationHashes(vault).length, 1);
-            assertEq(harness.exposed_vaultDelegationHashes(vault)[0], hash);
-            assertEq(harness.exposed_delegateDelegationHashes(delegate).length, 1);
-            assertEq(harness.exposed_delegateDelegationHashes(delegate)[0], hash);
+            assertEq(harness.exposed_outgoingDelegationHashes(vault).length, 1);
+            assertEq(harness.exposed_outgoingDelegationHashes(vault)[0], hash);
+            assertEq(harness.exposed_incomingDelegationHashes(delegate).length, 1);
+            assertEq(harness.exposed_incomingDelegationHashes(delegate)[0], hash);
         } else {
-            assertEq(harness.exposed_vaultDelegationHashes(vault).length, 0);
-            assertEq(harness.exposed_delegateDelegationHashes(delegate).length, 0);
+            assertEq(harness.exposed_outgoingDelegationHashes(vault).length, 0);
+            assertEq(harness.exposed_incomingDelegationHashes(delegate).length, 0);
         }
     }
 

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -62,16 +62,16 @@ contract RegistryUnitTests is Test {
         for (uint256 i = 0; i < negativeCases.length; i++) {
             cases = new bytes[](1);
             cases[0] = negativeCases[i];
-            vm.expectRevert(bytes("multicall failed"));
+            vm.expectRevert(IRegistry.MulticallFailed.selector);
             registry.multicall(cases);
         }
         // Negative multiple case
         cases = _randomizeAndReduce(negativeCases, negativeCases);
-        vm.expectRevert(bytes("multicall failed"));
+        vm.expectRevert(IRegistry.MulticallFailed.selector);
         registry.multicall(cases);
         // Multiple negative or positive cases (at least one of both)
         cases = _randomizeAndReduce(positiveCases, negativeCases);
-        vm.expectRevert(bytes("multicall failed"));
+        vm.expectRevert(IRegistry.MulticallFailed.selector);
         registry.multicall(cases);
     }
 

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -168,7 +168,7 @@ contract RegistryUnitTests is Test {
      * ----------- delegate methods -----------
      */
 
-    event AllDelegated(address indexed vault, address indexed delegate, bytes32 rights, bool enable);
+    event DelegateAll(address indexed vault, address indexed delegate, bytes32 rights, bool enable);
 
     function testDelegateAll(address vault, address delegate, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
@@ -185,7 +185,7 @@ contract RegistryUnitTests is Test {
             // Test correct event emitted
             vm.startPrank(vault);
             vm.expectEmit(true, true, true, true, address(harness));
-            emit AllDelegated(vault, delegate, rights, enable);
+            emit DelegateAll(vault, delegate, rights, enable);
             harness.delegateAll(delegate, rights, enable);
             vm.stopPrank();
             // Hashes should now exist regardless of true or false
@@ -197,7 +197,7 @@ contract RegistryUnitTests is Test {
                 // Disable again
                 vm.startPrank(vault);
                 vm.expectEmit(true, true, true, true, address(harness));
-                emit AllDelegated(vault, delegate, rights, false);
+                emit DelegateAll(vault, delegate, rights, false);
                 harness.delegateAll(delegate, rights, false);
                 vm.stopPrank();
                 // There should be no change to the hash mappings
@@ -210,7 +210,7 @@ contract RegistryUnitTests is Test {
         }
     }
 
-    event ContractDelegated(address indexed vault, address indexed delegate, address indexed contract_, bytes32 rights, bool enable);
+    event DelegateContract(address indexed vault, address indexed delegate, address indexed contract_, bytes32 rights, bool enable);
 
     function testDelegateContract(address vault, address delegate, address contract_, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
@@ -221,7 +221,7 @@ contract RegistryUnitTests is Test {
         for (uint256 i = 0; i < n; i++) {
             vm.startPrank(vault);
             vm.expectEmit(true, true, true, true, address(harness));
-            emit ContractDelegated(vault, delegate, contract_, rights, enable);
+            emit DelegateContract(vault, delegate, contract_, rights, enable);
             harness.delegateContract(delegate, contract_, rights, enable);
             vm.stopPrank();
             _checkHashes(vault, delegate, hash, true);
@@ -229,7 +229,7 @@ contract RegistryUnitTests is Test {
                 _checkStorage(0, contract_, delegate, hash, rights, 0, vault);
                 vm.startPrank(vault);
                 vm.expectEmit(true, true, true, true, address(harness));
-                emit ContractDelegated(vault, delegate, contract_, rights, false);
+                emit DelegateContract(vault, delegate, contract_, rights, false);
                 harness.delegateContract(delegate, contract_, rights, false);
                 vm.stopPrank();
                 _checkHashes(vault, delegate, hash, true);
@@ -239,7 +239,7 @@ contract RegistryUnitTests is Test {
         }
     }
 
-    event ERC721Delegated(address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, bytes32 rights, bool enable);
+    event DelegateERC721(address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, bytes32 rights, bool enable);
 
     function testDelegateERC721(address vault, address delegate, address contract_, uint256 tokenId, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
@@ -250,7 +250,7 @@ contract RegistryUnitTests is Test {
         for (uint256 i = 0; i < n; i++) {
             vm.startPrank(vault);
             vm.expectEmit(true, true, true, true, address(harness));
-            emit ERC721Delegated(vault, delegate, contract_, tokenId, rights, enable);
+            emit DelegateERC721(vault, delegate, contract_, tokenId, rights, enable);
             harness.delegateERC721(delegate, contract_, tokenId, rights, enable);
             vm.stopPrank();
             _checkHashes(vault, delegate, hash, true);
@@ -258,7 +258,7 @@ contract RegistryUnitTests is Test {
                 _checkStorage(0, contract_, delegate, hash, rights, tokenId, vault);
                 vm.startPrank(vault);
                 vm.expectEmit(true, true, true, true, address(harness));
-                emit ERC721Delegated(vault, delegate, contract_, tokenId, rights, false);
+                emit DelegateERC721(vault, delegate, contract_, tokenId, rights, false);
                 harness.delegateERC721(delegate, contract_, tokenId, rights, false);
                 vm.stopPrank();
                 _checkHashes(vault, delegate, hash, true);
@@ -268,7 +268,7 @@ contract RegistryUnitTests is Test {
         }
     }
 
-    event ERC20Delegated(address indexed vault, address indexed delegate, address indexed contract_, uint256 amount, bytes32 rights, bool enable);
+    event DelegateERC20(address indexed vault, address indexed delegate, address indexed contract_, uint256 amount, bytes32 rights, bool enable);
 
     function testDelegateERC20(address vault, address delegate, address contract_, uint256 amount, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
@@ -279,14 +279,14 @@ contract RegistryUnitTests is Test {
         for (uint256 i = 0; i < n; i++) {
             vm.startPrank(vault);
             vm.expectEmit(true, true, true, true, address(harness));
-            emit ERC20Delegated(vault, delegate, contract_, amount, rights, enable);
+            emit DelegateERC20(vault, delegate, contract_, amount, rights, enable);
             harness.delegateERC20(delegate, contract_, amount, rights, enable);
             vm.stopPrank();
             _checkHashes(vault, delegate, hash, true);
             if (enable) {
                 _checkStorage(amount, contract_, delegate, hash, rights, 0, vault);
                 vm.startPrank(vault);
-                emit ERC20Delegated(vault, delegate, contract_, amount, rights, false);
+                emit DelegateERC20(vault, delegate, contract_, amount, rights, false);
                 harness.delegateERC20(delegate, contract_, amount, rights, false);
                 vm.stopPrank();
                 _checkHashes(vault, delegate, hash, true);
@@ -297,7 +297,7 @@ contract RegistryUnitTests is Test {
         }
     }
 
-    event ERC1155Delegated(
+    event DelegateERC1155(
         address indexed vault, address indexed delegate, address indexed contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable
     );
 
@@ -310,14 +310,14 @@ contract RegistryUnitTests is Test {
         for (uint256 i = 0; i < (1 + amount % 10); i++) {
             vm.startPrank(vault);
             vm.expectEmit(true, true, true, true, address(harness));
-            emit ERC1155Delegated(vault, delegate, contract_, tokenId, amount, rights, enable);
+            emit DelegateERC1155(vault, delegate, contract_, tokenId, amount, rights, enable);
             harness.delegateERC1155(delegate, contract_, tokenId, amount, rights, enable);
             vm.stopPrank();
             _checkHashes(vault, delegate, hash, true);
             if (enable) {
                 _checkStorage(amount, contract_, delegate, hash, rights, tokenId, vault);
                 vm.startPrank(vault);
-                emit ERC1155Delegated(vault, delegate, contract_, tokenId, amount, rights, false);
+                emit DelegateERC1155(vault, delegate, contract_, tokenId, amount, rights, false);
                 harness.delegateERC1155(delegate, contract_, tokenId, amount, rights, false);
                 vm.stopPrank();
                 _checkHashes(vault, delegate, hash, true);


### PR DESCRIPTION
gas optimizations, rename events, add multicall error, return DelegationType.NONE in getDelegationsFromHashes if delegation unknown/existed