### PR TITLE
linearize checks

### DIFF
--- a/gasbenchmark10mil
+++ b/gasbenchmark10mil
@@ -1,16 +1,16 @@
 | src/DelegateRegistry.sol:DelegateRegistry contract |                 |        |        |        |         |
 |----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                    | Deployment Size |        |        |        |         |
-| 1687171                                            | 8459            |        |        |        |         |
+| 1688571                                            | 8466            |        |        |        |         |
 | Function Name                                      | min             | avg    | median | max    | # calls |
 | checkDelegateForAll                                | 3330            | 3693   | 3693   | 4056   | 2       |
 | checkDelegateForContract                           | 6226            | 6977   | 6977   | 7729   | 2       |
-| checkDelegateForERC1155                            | 9255            | 11305  | 11305  | 13355  | 2       |
+| checkDelegateForERC1155                            | 9259            | 11311  | 11311  | 13363  | 2       |
 | checkDelegateForERC20                              | 9169            | 11199  | 11199  | 13229  | 2       |
-| checkDelegateForERC721                             | 9194            | 11204  | 11204  | 13214  | 2       |
+| checkDelegateForERC721                             | 9185            | 10341  | 10341  | 11497  | 2       |
 | delegateAll                                        | 136145          | 136145 | 136145 | 136145 | 2       |
 | delegateContract                                   | 136874          | 147824 | 147824 | 158774 | 2       |
-| delegateERC1155                                    | 181783          | 192733 | 192733 | 203683 | 2       |
+| delegateERC1155                                    | 181787          | 192737 | 192737 | 203687 | 2       |
 | delegateERC20                                      | 159294          | 170244 | 170244 | 181194 | 2       |
-| delegateERC721                                     | 159345          | 170295 | 170295 | 181245 | 2       |
-| multicall                                          | 778722          | 778722 | 778722 | 778722 | 1       |
+| delegateERC721                                     | 159349          | 170299 | 170299 | 181249 | 2       |
+| multicall                                          | 778730          | 778730 | 778730 | 778730 | 1       |

--- a/gasbenchmark10mil
+++ b/gasbenchmark10mil
@@ -1,16 +1,16 @@
 | src/DelegateRegistry.sol:DelegateRegistry contract |                 |        |        |        |         |
 |----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                    | Deployment Size |        |        |        |         |
-| 1692178                                            | 8484            |        |        |        |         |
+| 1687171                                            | 8459            |        |        |        |         |
 | Function Name                                      | min             | avg    | median | max    | # calls |
-| checkDelegateForAll                                | 3339            | 3704   | 3704   | 4069   | 2       |
-| checkDelegateForContract                           | 6244            | 7417   | 7417   | 8590   | 2       |
-| checkDelegateForERC1155                            | 9273            | 11753  | 11753  | 14234  | 2       |
-| checkDelegateForERC20                              | 9183            | 11640  | 11640  | 14097  | 2       |
-| checkDelegateForERC721                             | 9212            | 11652  | 11652  | 14093  | 2       |
-| delegateAll                                        | 136141          | 136141 | 136141 | 136141 | 2       |
-| delegateContract                                   | 136870          | 147820 | 147820 | 158770 | 2       |
+| checkDelegateForAll                                | 3330            | 3693   | 3693   | 4056   | 2       |
+| checkDelegateForContract                           | 6226            | 6977   | 6977   | 7729   | 2       |
+| checkDelegateForERC1155                            | 9255            | 11305  | 11305  | 13355  | 2       |
+| checkDelegateForERC20                              | 9169            | 11199  | 11199  | 13229  | 2       |
+| checkDelegateForERC721                             | 9194            | 11204  | 11204  | 13214  | 2       |
+| delegateAll                                        | 136145          | 136145 | 136145 | 136145 | 2       |
+| delegateContract                                   | 136874          | 147824 | 147824 | 158774 | 2       |
 | delegateERC1155                                    | 181783          | 192733 | 192733 | 203683 | 2       |
-| delegateERC20                                      | 159290          | 170240 | 170240 | 181190 | 2       |
+| delegateERC20                                      | 159294          | 170244 | 170244 | 181194 | 2       |
 | delegateERC721                                     | 159345          | 170295 | 170295 | 181245 | 2       |
-| multicall                                          | 778710          | 778710 | 778710 | 778710 | 1       |
+| multicall                                          | 778722          | 778722 | 778722 | 778722 | 1       |

--- a/gasbenchmark10mil
+++ b/gasbenchmark10mil
@@ -1,13 +1,13 @@
 | src/DelegateRegistry.sol:DelegateRegistry contract |                 |        |        |        |         |
 |----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                    | Deployment Size |        |        |        |         |
-| 1688571                                            | 8466            |        |        |        |         |
+| 1721806                                            | 8632            |        |        |        |         |
 | Function Name                                      | min             | avg    | median | max    | # calls |
 | checkDelegateForAll                                | 3330            | 3693   | 3693   | 4056   | 2       |
-| checkDelegateForContract                           | 6226            | 6977   | 6977   | 7729   | 2       |
-| checkDelegateForERC1155                            | 9259            | 11311  | 11311  | 13363  | 2       |
-| checkDelegateForERC20                              | 9169            | 11199  | 11199  | 13229  | 2       |
-| checkDelegateForERC721                             | 9185            | 10341  | 10341  | 11497  | 2       |
+| checkDelegateForContract                           | 6127            | 6878   | 6878   | 7630   | 2       |
+| checkDelegateForERC1155                            | 9056            | 10254  | 10254  | 11452  | 2       |
+| checkDelegateForERC20                              | 8966            | 10142  | 10142  | 11319  | 2       |
+| checkDelegateForERC721                             | 8982            | 10138  | 10138  | 11294  | 2       |
 | delegateAll                                        | 136145          | 136145 | 136145 | 136145 | 2       |
 | delegateContract                                   | 136874          | 147824 | 147824 | 158774 | 2       |
 | delegateERC1155                                    | 181787          | 192737 | 192737 | 203687 | 2       |

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -160,21 +160,21 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForAll(address to, address from, bytes32 rights) public view override returns (bool valid) {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForAll(to, "", from));
-        valid = _validateDelegation(location, from);
+        valid = _validateDelegation(_computeDelegationLocation(_computeDelegationHashForAll(to, "", from)), from);
         if (rights != "" && !valid) {
-            location = _computeDelegationLocation(_computeDelegationHashForAll(to, rights, from));
-            valid = _validateDelegation(location, from);
+            valid = _validateDelegation(_computeDelegationLocation(_computeDelegationHashForAll(to, rights, from)), from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForContract(address to, address from, address contract_, bytes32 rights) public view override returns (bool valid) {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForContract(contract_, to, "", from));
-        valid = checkDelegateForAll(to, from, "") || _validateDelegation(location, from);
+        valid = checkDelegateForAll(to, from, "")
+            || _validateDelegation(_computeDelegationLocation(_computeDelegationHashForContract(contract_, to, "", from)), from);
         if (rights != "" && !valid) {
-            location = _computeDelegationLocation(_computeDelegationHashForContract(contract_, to, rights, from));
-            valid = checkDelegateForAll(to, from, rights) || _validateDelegation(location, from);
+            valid = (
+                _validateDelegation(_computeDelegationLocation(_computeDelegationHashForAll(to, rights, from)), from)
+                    || _validateDelegation(_computeDelegationLocation(_computeDelegationHashForContract(contract_, to, rights, from)), from)
+            );
         }
     }
 

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -52,8 +52,8 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function delegateAll(address to, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeDelegationHashForAll(to, rights, msg.sender);
-        bytes32 location = _computeDelegationLocation(hash);
+        bytes32 hash = _computeHashForAll(to, rights, msg.sender);
+        bytes32 location = _computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.to, to);
@@ -69,8 +69,8 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function delegateContract(address to, address contract_, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeDelegationHashForContract(contract_, to, rights, msg.sender);
-        bytes32 location = _computeDelegationLocation(hash);
+        bytes32 hash = _computeHashForContract(contract_, to, rights, msg.sender);
+        bytes32 location = _computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
@@ -88,8 +88,8 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function delegateERC721(address to, address contract_, uint256 tokenId, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeDelegationHashForERC721(contract_, to, rights, tokenId, msg.sender);
-        bytes32 location = _computeDelegationLocation(hash);
+        bytes32 hash = _computeHashForERC721(contract_, to, rights, tokenId, msg.sender);
+        bytes32 location = _computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
@@ -109,8 +109,8 @@ contract DelegateRegistry is IDelegateRegistry {
 
     // @inheritdoc IDelegateRegistry
     function delegateERC20(address to, address contract_, uint256 amount, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeDelegationHashForERC20(contract_, to, rights, msg.sender);
-        bytes32 location = _computeDelegationLocation(hash);
+        bytes32 hash = _computeHashForERC20(contract_, to, rights, msg.sender);
+        bytes32 location = _computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
@@ -133,8 +133,8 @@ contract DelegateRegistry is IDelegateRegistry {
      * @dev The actual amount is not encoded in the hash, just the existence of a amount (since it is an upper bound)
      */
     function delegateERC1155(address to, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeDelegationHashForERC1155(contract_, to, rights, tokenId, msg.sender);
-        bytes32 location = _computeDelegationLocation(hash);
+        bytes32 hash = _computeHashForERC1155(contract_, to, rights, tokenId, msg.sender);
+        bytes32 location = _computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
@@ -160,42 +160,44 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForAll(address to, address from, bytes32 rights) public view override returns (bool valid) {
-        valid = _validateDelegation(_computeDelegationLocation(_computeDelegationHashForAll(to, "", from)), from);
+        valid = _validateDelegation(_computeLocation(_computeHashForAll(to, "", from)), from);
         if (rights != "" && !valid) {
-            valid = _validateDelegation(_computeDelegationLocation(_computeDelegationHashForAll(to, rights, from)), from);
+            valid = _validateDelegation(_computeLocation(_computeHashForAll(to, rights, from)), from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForContract(address to, address from, address contract_, bytes32 rights) public view override returns (bool valid) {
-        valid = checkDelegateForAll(to, from, "")
-            || _validateDelegation(_computeDelegationLocation(_computeDelegationHashForContract(contract_, to, "", from)), from);
+        valid = checkDelegateForAll(to, from, "") || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, "", from)), from);
         if (rights != "" && !valid) {
             valid = (
-                _validateDelegation(_computeDelegationLocation(_computeDelegationHashForAll(to, rights, from)), from)
-                    || _validateDelegation(_computeDelegationLocation(_computeDelegationHashForContract(contract_, to, rights, from)), from)
+                _validateDelegation(_computeLocation(_computeHashForAll(to, rights, from)), from)
+                    || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, rights, from)), from)
             );
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForERC721(address to, address from, address contract_, uint256 tokenId, bytes32 rights) external view override returns (bool valid) {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC721(contract_, to, "", tokenId, from));
-        valid = checkDelegateForContract(to, from, contract_, "") || _validateDelegation(location, from);
+        valid = checkDelegateForContract(to, from, contract_, "")
+            || _validateDelegation(_computeLocation(_computeHashForERC721(contract_, to, "", tokenId, from)), from);
         if (rights != "" && !valid) {
-            location = _computeDelegationLocation(_computeDelegationHashForERC721(contract_, to, rights, tokenId, from));
-            valid = checkDelegateForContract(to, from, contract_, rights) || _validateDelegation(location, from);
+            valid = (
+                _validateDelegation(_computeLocation(_computeHashForAll(to, rights, from)), from)
+                    || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, rights, from)), from)
+                    || _validateDelegation(_computeLocation(_computeHashForERC721(contract_, to, rights, tokenId, from)), from)
+            );
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForERC20(address to, address from, address contract_, bytes32 rights) external view override returns (uint256 amount) {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC20(contract_, to, "", from));
+        bytes32 location = _computeLocation(_computeHashForERC20(contract_, to, "", from));
         amount = checkDelegateForContract(to, from, contract_, "")
             ? type(uint256).max
             : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
         if (rights != "" && amount != type(uint256).max) {
-            location = _computeDelegationLocation(_computeDelegationHashForERC20(contract_, to, rights, from));
+            location = _computeLocation(_computeHashForERC20(contract_, to, rights, from));
             uint256 rightsBalance = checkDelegateForContract(to, from, contract_, rights)
                 ? type(uint256).max
                 : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
@@ -210,12 +212,12 @@ contract DelegateRegistry is IDelegateRegistry {
         override
         returns (uint256 amount)
     {
-        bytes32 location = _computeDelegationLocation(_computeDelegationHashForERC1155(contract_, to, "", tokenId, from));
+        bytes32 location = _computeLocation(_computeHashForERC1155(contract_, to, "", tokenId, from));
         amount = checkDelegateForContract(to, from, contract_, "")
             ? type(uint256).max
             : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
         if (rights != "" && amount != type(uint256).max) {
-            location = _computeDelegationLocation(_computeDelegationHashForERC1155(contract_, to, rights, tokenId, from));
+            location = _computeLocation(_computeHashForERC1155(contract_, to, rights, tokenId, from));
             uint256 rightsBalance = checkDelegateForContract(to, from, contract_, rights)
                 ? type(uint256).max
                 : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
@@ -254,7 +256,7 @@ contract DelegateRegistry is IDelegateRegistry {
         address from;
         unchecked {
             for (uint256 i = 0; i < hashes.length; ++i) {
-                location = _computeDelegationLocation(hashes[i]);
+                location = _computeLocation(hashes[i]);
                 from = _loadDelegationAddress(location, StoragePositions.from);
                 if (from == DELEGATION_EMPTY || from == DELEGATION_REVOKED) {
                     delegations[i] =
@@ -290,27 +292,27 @@ contract DelegateRegistry is IDelegateRegistry {
      */
 
     /// @dev Helper function to compute delegation hash for all delegation
-    function _computeDelegationHashForAll(address to, bytes32 rights, address from) internal pure returns (bytes32) {
+    function _computeHashForAll(address to, bytes32 rights, address from) internal pure returns (bytes32) {
         return _encodeLastByteWithType(keccak256(abi.encode(to, rights, from)), DelegationType.ALL);
     }
 
     /// @dev Helper function to compute delegation hash for contract delegation
-    function _computeDelegationHashForContract(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
+    function _computeHashForContract(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
         return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), DelegationType.CONTRACT);
     }
 
     /// @dev Helper function to compute delegation hash for ERC721 delegation
-    function _computeDelegationHashForERC721(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
+    function _computeHashForERC721(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
         return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), DelegationType.ERC721);
     }
 
     /// @dev Helper function to compute delegation hash for ERC20 delegation
-    function _computeDelegationHashForERC20(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
+    function _computeHashForERC20(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
         return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), DelegationType.ERC20);
     }
 
     /// @dev Helper function to compute delegation hash for ERC1155 delegation
-    function _computeDelegationHashForERC1155(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
+    function _computeHashForERC1155(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
         return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), DelegationType.ERC1155);
     }
 
@@ -325,7 +327,7 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @dev Helper function that computes the data location of a particular delegation hash
-    function _computeDelegationLocation(bytes32 hash) internal pure returns (bytes32 location) {
+    function _computeLocation(bytes32 hash) internal pure returns (bytes32 location) {
         location = keccak256(abi.encode(hash, 0)); // _delegations mapping is at slot 0
     }
 
@@ -369,7 +371,7 @@ contract DelegateRegistry is IDelegateRegistry {
         unchecked {
             for (uint256 i = 0; i < hashesLength; ++i) {
                 hash = hashes[i];
-                if (_loadDelegationAddress(_computeDelegationLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) {
+                if (_loadDelegationAddress(_computeLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) {
                     filteredHashes[count] = hash;
                     ++count;
                 }
@@ -379,7 +381,7 @@ contract DelegateRegistry is IDelegateRegistry {
             address from;
             for (uint256 i = 0; i < count; ++i) {
                 hash = filteredHashes[i];
-                location = _computeDelegationLocation(hash);
+                location = _computeLocation(hash);
                 from = _loadDelegationAddress(location, StoragePositions.from);
                 delegations[i] = Delegation({
                     type_: _decodeLastByteToType(hash),
@@ -403,7 +405,7 @@ contract DelegateRegistry is IDelegateRegistry {
         unchecked {
             for (uint256 i = 0; i < hashesLength; ++i) {
                 hash = hashes[i];
-                if (_loadDelegationAddress(_computeDelegationLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) {
+                if (_loadDelegationAddress(_computeLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) {
                     filteredHashes[count] = hash;
                     ++count;
                 }

--- a/src/tools/RegistryHarness.sol
+++ b/src/tools/RegistryHarness.sol
@@ -17,32 +17,32 @@ contract RegistryHarness is DelegateRegistry {
         return _incomingDelegationHashes[delegate];
     }
 
-    function exposed_computeDelegationHashForAll(address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return _computeDelegationHashForAll(delegate, rights, vault);
+    function exposed_computeHashForAll(address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
+        return _computeHashForAll(delegate, rights, vault);
     }
 
-    function exposed_computeDelegationHashForContract(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return _computeDelegationHashForContract(contract_, delegate, rights, vault);
+    function exposed_computeHashForContract(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
+        return _computeHashForContract(contract_, delegate, rights, vault);
     }
 
-    function exposed_computeDelegationHashForERC721(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault)
+    function exposed_computeHashForERC721(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault)
         external
         pure
         returns (bytes32)
     {
-        return _computeDelegationHashForERC721(contract_, delegate, rights, tokenId, vault);
+        return _computeHashForERC721(contract_, delegate, rights, tokenId, vault);
     }
 
-    function exposed_computeDelegationHashForERC20(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return _computeDelegationHashForERC20(contract_, delegate, rights, vault);
+    function exposed_computeHashForERC20(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
+        return _computeHashForERC20(contract_, delegate, rights, vault);
     }
 
-    function exposed_computeDelegationHashForERC1155(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault)
+    function exposed_computeHashForERC1155(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault)
         external
         pure
         returns (bytes32)
     {
-        return _computeDelegationHashForERC1155(contract_, delegate, rights, tokenId, vault);
+        return _computeHashForERC1155(contract_, delegate, rights, tokenId, vault);
     }
 
     function exposed_encodeLastByteWithType(bytes32 _input, DelegationType _type) external pure returns (bytes32) {
@@ -53,7 +53,7 @@ contract RegistryHarness is DelegateRegistry {
         return _decodeLastByteToType(_input);
     }
 
-    function exposed_computeDelegationLocation(bytes32 hash) external pure returns (bytes32 location) {
-        return _computeDelegationLocation(hash);
+    function exposed_computeLocation(bytes32 hash) external pure returns (bytes32 location) {
+        return _computeLocation(hash);
     }
 }

--- a/test/RegistrySingularIntegrations.t.sol
+++ b/test/RegistrySingularIntegrations.t.sol
@@ -158,16 +158,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeDelegationHashForAll(_delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForAll(_delegate, _rights, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeDelegationHashForAll(_delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForAll(_delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeDelegationHashForAll(_delegate, _rights, _vault);
+        hashes[0] = harness.exposed_computeHashForAll(_delegate, _rights, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -269,18 +269,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(
-                registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeDelegationHashForContract(_contract, _delegate, _rights, _vault)
-            );
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForContract(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeDelegationHashForContract(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForContract(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeDelegationHashForContract(_contract, _delegate, _rights, _vault);
+        hashes[0] = harness.exposed_computeHashForContract(_contract, _delegate, _rights, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -371,21 +369,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(
-                registry.getIncomingDelegationHashes(_delegate)[0],
-                harness.exposed_computeDelegationHashForERC721(_contract, _delegate, _rights, _tokenId, _vault)
-            );
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(
-                registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeDelegationHashForERC721(_contract, _delegate, _rights, _tokenId, _vault)
-            );
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeDelegationHashForERC721(_contract, _delegate, _rights, _tokenId, _vault);
+        hashes[0] = harness.exposed_computeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -478,16 +471,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForERC20(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForERC20(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeDelegationHashForERC20(_contract, _delegate, _rights, _vault);
+        hashes[0] = harness.exposed_computeHashForERC20(_contract, _delegate, _rights, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -582,22 +575,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(
-                registry.getIncomingDelegationHashes(_delegate)[0],
-                harness.exposed_computeDelegationHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault)
-            );
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(
-                registry.getOutgoingDelegationHashes(_vault)[0],
-                harness.exposed_computeDelegationHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault)
-            );
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeDelegationHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault);
+        hashes[0] = harness.exposed_computeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -175,7 +175,7 @@ contract RegistryUnitTests is Test {
         // Create new harness
         harness = new Harness();
         // Calculate hash
-        bytes32 hash = harness.exposed_computeDelegationHashForAll(delegate, rights, vault);
+        bytes32 hash = harness.exposed_computeHashForAll(delegate, rights, vault);
         // Hashes should not exist yet
         _checkHashes(vault, delegate, hash, false);
         // Storage should not exist yet
@@ -215,7 +215,7 @@ contract RegistryUnitTests is Test {
     function testDelegateContract(address vault, address delegate, address contract_, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
         harness = new Harness();
-        bytes32 hash = harness.exposed_computeDelegationHashForContract(contract_, delegate, rights, vault);
+        bytes32 hash = harness.exposed_computeHashForContract(contract_, delegate, rights, vault);
         _checkHashes(vault, delegate, hash, false);
         _checkStorage(0, address(0), address(0), hash, 0, 0, address(0));
         for (uint256 i = 0; i < n; i++) {
@@ -244,7 +244,7 @@ contract RegistryUnitTests is Test {
     function testDelegateERC721(address vault, address delegate, address contract_, uint256 tokenId, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
         harness = new Harness();
-        bytes32 hash = harness.exposed_computeDelegationHashForERC721(contract_, delegate, rights, tokenId, vault);
+        bytes32 hash = harness.exposed_computeHashForERC721(contract_, delegate, rights, tokenId, vault);
         _checkHashes(vault, delegate, hash, false);
         _checkStorage(0, address(0), address(0), hash, 0, 0, address(0));
         for (uint256 i = 0; i < n; i++) {
@@ -273,7 +273,7 @@ contract RegistryUnitTests is Test {
     function testDelegateERC20(address vault, address delegate, address contract_, uint256 amount, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
         harness = new Harness();
-        bytes32 hash = harness.exposed_computeDelegationHashForERC20(contract_, delegate, rights, vault);
+        bytes32 hash = harness.exposed_computeHashForERC20(contract_, delegate, rights, vault);
         _checkHashes(vault, delegate, hash, false);
         _checkStorage(0, address(0), address(0), hash, 0, 0, address(0));
         for (uint256 i = 0; i < n; i++) {
@@ -304,7 +304,7 @@ contract RegistryUnitTests is Test {
     function testDelegateERC1155(address vault, address delegate, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) public {
         vm.assume(vault > address(1));
         harness = new Harness();
-        bytes32 hash = harness.exposed_computeDelegationHashForERC1155(contract_, delegate, rights, tokenId, vault);
+        bytes32 hash = harness.exposed_computeHashForERC1155(contract_, delegate, rights, tokenId, vault);
         _checkHashes(vault, delegate, hash, false);
         _checkStorage(0, address(0), address(0), hash, 0, 0, address(0));
         for (uint256 i = 0; i < (1 + amount % 10); i++) {


### PR DESCRIPTION
Status quo has some duplicate bubbling up if we don't hit an immediate success on checkContract and checkERC721/20/1155. It's worse on checking tokens, which is what integrators are encouraged to do. And it'll fail in the majority of those cases. This outlines the problem. This is fixed by linearizing, first check the empty rights field linearly all the way up to All, then check the specific subdelegation rights field linearly all the way up to all. No overlaps.

<img width="1124" alt="Screenshot 2023-06-13 at 2 46 07 AM" src="https://github.com/delegatecash/delegate-registry/assets/83792390/125dd320-5d1f-4308-a723-94c80602c25e">
