### PR TITLE
Slither report action, IR optimizer, minor style convention edits

### DIFF
--- a/.github/workflows/slither-report.yml
+++ b/.github/workflows/slither-report.yml
@@ -1,0 +1,32 @@
+name: Slither Report
+
+on: [push, pull_request]
+
+jobs:
+  slither-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Foundry
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install dependencies
+        run: forge install
+
+      - name: Install slither
+        run: pip install slither-analyzer
+      
+      - name: Forge clean
+        run: forge clean
+      
+      - name: Forge build without test & script
+        run: forge build --build-info --skip test --skip script
+      
+      - name: Generate slither report
+        run: slither . --compile-force-framework "foundry" --foundry-out-directory "out" --ignore-compile --fail-medium --skip-clean --filter-paths "lib" --checklist --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/ > slitherReport.md

--- a/foundry.toml
+++ b/foundry.toml
@@ -10,9 +10,9 @@ evm_version = "paris"
 optimizer_runs = 9_999_999
 # Get reproducible bytecode across machines by removing metadata hash from runtime bytecode, also saves 41 deployment size
 bytecode_hash = "none"
-# Increases deployment size by 10%, cuts down on runtime gas costs by ~1%,, increases compiletime 10x. Enable on deployment
-# via_ir = true
-# extra_output_files = ['irOptimized']
+# Disable ir optimizer, minimal gas savings not worth the potential for bugs
+via_ir = false
+
 
 [fmt]
 line_length = 170

--- a/slitherReport.md
+++ b/slitherReport.md
@@ -1,0 +1,134 @@
+**THIS CHECKLIST IS NOT COMPLETE**. Use `--show-ignored-findings` to show all the results.
+Summary
+ - [shadowing-local](#shadowing-local) (1 results) (Low)
+ - [missing-zero-check](#missing-zero-check) (1 results) (Low)
+ - [calls-loop](#calls-loop) (1 results) (Low)
+ - [assembly](#assembly) (6 results) (Informational)
+ - [solc-version](#solc-version) (7 results) (Informational)
+ - [low-level-calls](#low-level-calls) (1 results) (Informational)
+## shadowing-local
+Impact: Low
+Confidence: High
+ - [ ] ID-0
+[Airdrop.constructor(address,address,bytes32,uint256,bytes32,address).acceptedRight](src/examples/Airdrop.sol#L27) shadows:
+	- [DelegateClaim.acceptedRight](src/examples/DelegateClaim.sol#L14) (state variable)
+
+src/examples/Airdrop.sol#L27
+
+
+## missing-zero-check
+Impact: Low
+Confidence: Medium
+ - [ ] ID-1
+[DelegateClaim.constructor(address,address,bytes32).referenceToken_](src/examples/DelegateClaim.sol#L24) lacks a zero-check on :
+		- [referenceToken = referenceToken_](src/examples/DelegateClaim.sol#L26)
+
+src/examples/DelegateClaim.sol#L24
+
+
+## calls-loop
+Impact: Low
+Confidence: Medium
+ - [ ] ID-2
+[DelegateRegistry.multicall(bytes[])](src/DelegateRegistry.sol#L42-L51) has external calls inside a loop: [(success,results[i]) = address(this).delegatecall(data[i])](src/DelegateRegistry.sol#L47)
+
+src/DelegateRegistry.sol#L42-L51
+
+
+## assembly
+Impact: Informational
+Confidence: High
+ - [ ] ID-3
+[DelegateRegistry._loadDelegationUint(bytes32,DelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L416-L420) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L417-L419)
+
+src/DelegateRegistry.sol#L416-L420
+
+
+ - [ ] ID-4
+[DelegateRegistry._writeDelegation(bytes32,DelegateRegistry.StoragePositions,address)](src/DelegateRegistry.sol#L353-L357) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L354-L356)
+
+src/DelegateRegistry.sol#L353-L357
+
+
+ - [ ] ID-5
+[DelegateRegistry._loadDelegationAddress(bytes32,DelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L423-L427) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L424-L426)
+
+src/DelegateRegistry.sol#L423-L427
+
+
+ - [ ] ID-6
+[DelegateRegistry._writeDelegation(bytes32,DelegateRegistry.StoragePositions,bytes32)](src/DelegateRegistry.sol#L339-L343) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L340-L342)
+
+src/DelegateRegistry.sol#L339-L343
+
+
+ - [ ] ID-7
+[DelegateRegistry._writeDelegation(bytes32,DelegateRegistry.StoragePositions,uint256)](src/DelegateRegistry.sol#L346-L350) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L347-L349)
+
+src/DelegateRegistry.sol#L346-L350
+
+
+ - [ ] ID-8
+[DelegateRegistry._loadDelegationBytes32(bytes32,DelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L409-L413) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L410-L412)
+
+src/DelegateRegistry.sol#L409-L413
+
+
+## solc-version
+Impact: Informational
+Confidence: High
+ - [ ] ID-9
+Pragma version[>=0.8.13](src/IDelegateRegistry.sol#L2) allows old versions
+
+src/IDelegateRegistry.sol#L2
+
+
+ - [ ] ID-10
+Pragma version[^0.8.20](src/examples/Airdrop.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
+
+src/examples/Airdrop.sol#L2
+
+
+ - [ ] ID-11
+solc-0.8.20 is not recommended for deployment
+
+ - [ ] ID-12
+Pragma version[^0.8.20](src/tools/RegistryHarness.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
+
+src/tools/RegistryHarness.sol#L2
+
+
+ - [ ] ID-13
+Pragma version[^0.8.20](src/examples/IPLicenseCheck.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
+
+src/examples/IPLicenseCheck.sol#L2
+
+
+ - [ ] ID-14
+Pragma version[^0.8.20](src/DelegateRegistry.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
+
+src/DelegateRegistry.sol#L2
+
+
+ - [ ] ID-15
+Pragma version[^0.8.20](src/examples/DelegateClaim.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
+
+src/examples/DelegateClaim.sol#L2
+
+
+## low-level-calls
+Impact: Informational
+Confidence: High
+ - [ ] ID-16
+Low level call in [DelegateRegistry.multicall(bytes[])](src/DelegateRegistry.sol#L42-L51):
+	- [(success,results[i]) = address(this).delegatecall(data[i])](src/DelegateRegistry.sol#L47)
+
+src/DelegateRegistry.sol#L42-L51
+
+

--- a/src/tools/RegistryHarness.sol
+++ b/src/tools/RegistryHarness.sol
@@ -5,47 +5,51 @@ import {DelegateRegistry} from "src/DelegateRegistry.sol";
 
 /// @dev harness contract that exposes internal registry methods as external ones
 contract RegistryHarness is DelegateRegistry {
-    function exposed_delegations(bytes32 hash) external view returns (bytes32[6] memory) {
-        return _delegations[hash];
+    constructor() {
+        delegations[0][0] = 0;
     }
 
-    function exposed_outgoingDelegationHashes(address vault) external view returns (bytes32[] memory) {
-        return _outgoingDelegationHashes[vault];
+    function exposedDelegations(bytes32 hash) external view returns (bytes32[6] memory) {
+        return delegations[hash];
     }
 
-    function exposed_incomingDelegationHashes(address delegate) external view returns (bytes32[] memory) {
-        return _incomingDelegationHashes[delegate];
+    function exposedOutgoingDelegationHashes(address vault) external view returns (bytes32[] memory) {
+        return outgoingDelegationHashes[vault];
     }
 
-    function exposed_computeHashForAll(address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
+    function exposedIncomingDelegationHashes(address delegate) external view returns (bytes32[] memory) {
+        return incomingDelegationHashes[delegate];
+    }
+
+    function exposedComputeHashForAll(address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
         return _computeHashForAll(delegate, rights, vault);
     }
 
-    function exposed_computeHashForContract(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
+    function exposedComputeHashForContract(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
         return _computeHashForContract(contract_, delegate, rights, vault);
     }
 
-    function exposed_computeHashForERC721(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault) external pure returns (bytes32) {
+    function exposedComputeHashForERC721(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault) external pure returns (bytes32) {
         return _computeHashForERC721(contract_, delegate, rights, tokenId, vault);
     }
 
-    function exposed_computeHashForERC20(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
+    function exposedComputeHashForERC20(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
         return _computeHashForERC20(contract_, delegate, rights, vault);
     }
 
-    function exposed_computeHashForERC1155(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault) external pure returns (bytes32) {
+    function exposedComputeHashForERC1155(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault) external pure returns (bytes32) {
         return _computeHashForERC1155(contract_, delegate, rights, tokenId, vault);
     }
 
-    function exposed_encodeLastByteWithType(bytes32 _input, DelegationType _type) external pure returns (bytes32) {
-        return _encodeLastByteWithType(_input, _type);
+    function exposedEncodeLastByteWithType(bytes32 input, DelegationType type_) external pure returns (bytes32) {
+        return _encodeLastByteWithType(input, type_);
     }
 
-    function exposed_decodeLastByteToType(bytes32 _input) external pure returns (DelegationType) {
-        return _decodeLastByteToType(_input);
+    function exposedDecodeLastByteToType(bytes32 input) external pure returns (DelegationType) {
+        return _decodeLastByteToType(input);
     }
 
-    function exposed_computeLocation(bytes32 hash) external pure returns (bytes32 location) {
+    function exposedComputeLocation(bytes32 hash) external pure returns (bytes32 location) {
         return _computeLocation(hash);
     }
 }

--- a/test/RegistrySingularIntegrations.t.sol
+++ b/test/RegistrySingularIntegrations.t.sol
@@ -155,16 +155,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForAll(_delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForAll(_delegate, _rights, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForAll(_delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForAll(_delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeHashForAll(_delegate, _rights, _vault);
+        hashes[0] = harness.exposedComputeHashForAll(_delegate, _rights, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -266,16 +266,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForContract(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForContract(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForContract(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForContract(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeHashForContract(_contract, _delegate, _rights, _vault);
+        hashes[0] = harness.exposedComputeHashForContract(_contract, _delegate, _rights, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -366,16 +366,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault);
+        hashes[0] = harness.exposedComputeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -468,16 +468,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForERC20(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForERC20(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForERC20(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForERC20(_contract, _delegate, _rights, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeHashForERC20(_contract, _delegate, _rights, _vault);
+        hashes[0] = harness.exposedComputeHashForERC20(_contract, _delegate, _rights, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -572,16 +572,16 @@ contract DelegateSingularIntegrations is Test {
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposed_computeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault));
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposed_computeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault));
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposed_computeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault);
+        hashes[0] = harness.exposedComputeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault);
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -171,7 +171,7 @@ contract RegistryUnitTests is Test {
         // Create new harness
         harness = new Harness();
         // Calculate hash
-        bytes32 hash = harness.exposed_computeHashForAll(delegate, rights, vault);
+        bytes32 hash = harness.exposedComputeHashForAll(delegate, rights, vault);
         // Hashes should not exist yet
         _checkHashes(vault, delegate, hash, false);
         // Storage should not exist yet
@@ -211,7 +211,7 @@ contract RegistryUnitTests is Test {
     function testDelegateContract(address vault, address delegate, address contract_, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
         harness = new Harness();
-        bytes32 hash = harness.exposed_computeHashForContract(contract_, delegate, rights, vault);
+        bytes32 hash = harness.exposedComputeHashForContract(contract_, delegate, rights, vault);
         _checkHashes(vault, delegate, hash, false);
         _checkStorage(0, address(0), address(0), hash, 0, 0, address(0));
         for (uint256 i = 0; i < n; i++) {
@@ -240,7 +240,7 @@ contract RegistryUnitTests is Test {
     function testDelegateERC721(address vault, address delegate, address contract_, uint256 tokenId, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
         harness = new Harness();
-        bytes32 hash = harness.exposed_computeHashForERC721(contract_, delegate, rights, tokenId, vault);
+        bytes32 hash = harness.exposedComputeHashForERC721(contract_, delegate, rights, tokenId, vault);
         _checkHashes(vault, delegate, hash, false);
         _checkStorage(0, address(0), address(0), hash, 0, 0, address(0));
         for (uint256 i = 0; i < n; i++) {
@@ -269,7 +269,7 @@ contract RegistryUnitTests is Test {
     function testDelegateERC20(address vault, address delegate, address contract_, uint256 amount, bytes32 rights, bool enable, uint256 n) public {
         vm.assume(vault > address(1) && n > 0 && n < 10);
         harness = new Harness();
-        bytes32 hash = harness.exposed_computeHashForERC20(contract_, delegate, rights, vault);
+        bytes32 hash = harness.exposedComputeHashForERC20(contract_, delegate, rights, vault);
         _checkHashes(vault, delegate, hash, false);
         _checkStorage(0, address(0), address(0), hash, 0, 0, address(0));
         for (uint256 i = 0; i < n; i++) {
@@ -298,7 +298,7 @@ contract RegistryUnitTests is Test {
     function testDelegateERC1155(address vault, address delegate, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) public {
         vm.assume(vault > address(1));
         harness = new Harness();
-        bytes32 hash = harness.exposed_computeHashForERC1155(contract_, delegate, rights, tokenId, vault);
+        bytes32 hash = harness.exposedComputeHashForERC1155(contract_, delegate, rights, tokenId, vault);
         _checkHashes(vault, delegate, hash, false);
         _checkStorage(0, address(0), address(0), hash, 0, 0, address(0));
         for (uint256 i = 0; i < (1 + amount % 10); i++) {
@@ -324,24 +324,24 @@ contract RegistryUnitTests is Test {
 
     function _checkHashes(address vault, address delegate, bytes32 hash, bool on) internal {
         if (on) {
-            assertEq(harness.exposed_outgoingDelegationHashes(vault).length, 1);
-            assertEq(harness.exposed_outgoingDelegationHashes(vault)[0], hash);
-            assertEq(harness.exposed_incomingDelegationHashes(delegate).length, 1);
-            assertEq(harness.exposed_incomingDelegationHashes(delegate)[0], hash);
+            assertEq(harness.exposedOutgoingDelegationHashes(vault).length, 1);
+            assertEq(harness.exposedOutgoingDelegationHashes(vault)[0], hash);
+            assertEq(harness.exposedIncomingDelegationHashes(delegate).length, 1);
+            assertEq(harness.exposedIncomingDelegationHashes(delegate)[0], hash);
         } else {
-            assertEq(harness.exposed_outgoingDelegationHashes(vault).length, 0);
-            assertEq(harness.exposed_incomingDelegationHashes(delegate).length, 0);
+            assertEq(harness.exposedOutgoingDelegationHashes(vault).length, 0);
+            assertEq(harness.exposedIncomingDelegationHashes(delegate).length, 0);
         }
     }
 
     function _checkStorage(uint256 amount, address contract_, address delegate, bytes32 hash, bytes32 rights, uint256 tokenId, address vault) internal {
-        assertEq(harness.exposed_delegations(hash).length, uint256(type(StoragePositions).max) + 1);
-        assertEq(address(uint160(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.to)]))), delegate);
-        assertEq(address(uint160(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.from)]))), vault);
-        assertEq(harness.exposed_delegations(hash)[uint256(StoragePositions.rights)], rights);
-        assertEq(address(uint160(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.contract_)]))), contract_);
-        assertEq(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.tokenId)]), tokenId);
-        assertEq(uint256(harness.exposed_delegations(hash)[uint256(StoragePositions.amount)]), amount);
+        assertEq(harness.exposedDelegations(hash).length, uint256(type(StoragePositions).max) + 1);
+        assertEq(address(uint160(uint256(harness.exposedDelegations(hash)[uint256(StoragePositions.to)]))), delegate);
+        assertEq(address(uint160(uint256(harness.exposedDelegations(hash)[uint256(StoragePositions.from)]))), vault);
+        assertEq(harness.exposedDelegations(hash)[uint256(StoragePositions.rights)], rights);
+        assertEq(address(uint160(uint256(harness.exposedDelegations(hash)[uint256(StoragePositions.contract_)]))), contract_);
+        assertEq(uint256(harness.exposedDelegations(hash)[uint256(StoragePositions.tokenId)]), tokenId);
+        assertEq(uint256(harness.exposedDelegations(hash)[uint256(StoragePositions.amount)]), amount);
     }
 
     /**


### PR DESCRIPTION
**Slither GitHub action:**
Excellent static analyser from Trail of Bits, have it set to run on src folder only (not on test or script) and to fail if medium severity issues are detected.

**IR optimizer:**
Really don't think it's worth ever turning this on since the gas & deployment benefits are microscopic and do not outweigh the potential for bugs.

**Minor naming convention edits:**
Picked up by Slither actually, convention is for no leading _ for state vars unless private.

**Cute cat photo:**

![Cute cat photo](https://wallup.net/wp-content/uploads/2018/10/07/458442-cat-animal-pet-cats-kitty-cute-sweet.jpg)