### PR TITLE
Returning delegate hashes, moved internal pure hash methods to library, external storage access methods

### DIFF
--- a/.github/workflows/slither-report.yml
+++ b/.github/workflows/slither-report.yml
@@ -30,3 +30,11 @@ jobs:
       
       - name: Generate slither report
         run: slither . --compile-force-framework "foundry" --foundry-out-directory "out" --ignore-compile --fail-medium --skip-clean --filter-paths "lib" --checklist --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/ > slitherReport.md
+
+      - name: Check slither report
+        run: |
+          section=$(awk '/^##/{exit} {print}' slitherReport.md)
+          if [[ $section == *"Medium"* || $section == *"High"* ]]; then
+            echo "Medium or High risk found in slither report. Failing the run."
+            exit 1
+          fi

--- a/slitherReport.md
+++ b/slitherReport.md
@@ -3,7 +3,7 @@ Summary
  - [shadowing-local](#shadowing-local) (1 results) (Low)
  - [missing-zero-check](#missing-zero-check) (1 results) (Low)
  - [calls-loop](#calls-loop) (1 results) (Low)
- - [assembly](#assembly) (6 results) (Informational)
+ - [assembly](#assembly) (8 results) (Informational)
  - [solc-version](#solc-version) (7 results) (Informational)
  - [low-level-calls](#low-level-calls) (1 results) (Informational)
 ## shadowing-local
@@ -30,93 +30,107 @@ src/examples/DelegateClaim.sol#L24
 Impact: Low
 Confidence: Medium
  - [ ] ID-2
-[DelegateRegistry.multicall(bytes[])](src/DelegateRegistry.sol#L42-L51) has external calls inside a loop: [(success,results[i]) = address(this).delegatecall(data[i])](src/DelegateRegistry.sol#L47)
+[DelegateRegistry.multicall(bytes[])](src/DelegateRegistry.sol#L34-L43) has external calls inside a loop: [(success,results[i]) = address(this).delegatecall(data[i])](src/DelegateRegistry.sol#L39)
 
-src/DelegateRegistry.sol#L42-L51
+src/DelegateRegistry.sol#L34-L43
 
 
 ## assembly
 Impact: Informational
 Confidence: High
  - [ ] ID-3
-[DelegateRegistry._loadDelegationUint(bytes32,DelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L416-L420) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L417-L419)
+[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,uint256)](src/DelegateRegistry.sol#L314-L318) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L315-L317)
 
-src/DelegateRegistry.sol#L416-L420
+src/DelegateRegistry.sol#L314-L318
 
 
  - [ ] ID-4
-[DelegateRegistry._writeDelegation(bytes32,DelegateRegistry.StoragePositions,address)](src/DelegateRegistry.sol#L353-L357) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L354-L356)
+[DelegateRegistry._loadDelegationUint(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L384-L388) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L385-L387)
 
-src/DelegateRegistry.sol#L353-L357
+src/DelegateRegistry.sol#L384-L388
 
 
  - [ ] ID-5
-[DelegateRegistry._loadDelegationAddress(bytes32,DelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L423-L427) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L424-L426)
+[DelegateRegistry.readSlots(bytes32[])](src/DelegateRegistry.sol#L277-L283) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L280-L282)
 
-src/DelegateRegistry.sol#L423-L427
+src/DelegateRegistry.sol#L277-L283
 
 
  - [ ] ID-6
-[DelegateRegistry._writeDelegation(bytes32,DelegateRegistry.StoragePositions,bytes32)](src/DelegateRegistry.sol#L339-L343) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L340-L342)
+[DelegateRegistry._loadDelegationBytes32(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L377-L381) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L378-L380)
 
-src/DelegateRegistry.sol#L339-L343
+src/DelegateRegistry.sol#L377-L381
 
 
  - [ ] ID-7
-[DelegateRegistry._writeDelegation(bytes32,DelegateRegistry.StoragePositions,uint256)](src/DelegateRegistry.sol#L346-L350) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L347-L349)
+[DelegateRegistry._loadDelegationAddress(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L391-L395) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L392-L394)
 
-src/DelegateRegistry.sol#L346-L350
+src/DelegateRegistry.sol#L391-L395
 
 
  - [ ] ID-8
-[DelegateRegistry._loadDelegationBytes32(bytes32,DelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L409-L413) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L410-L412)
+[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,bytes32)](src/DelegateRegistry.sol#L307-L311) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L308-L310)
 
-src/DelegateRegistry.sol#L409-L413
+src/DelegateRegistry.sol#L307-L311
+
+
+ - [ ] ID-9
+[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,address)](src/DelegateRegistry.sol#L321-L325) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L322-L324)
+
+src/DelegateRegistry.sol#L321-L325
+
+
+ - [ ] ID-10
+[DelegateRegistry.readSlot(bytes32)](src/DelegateRegistry.sol#L271-L275) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L272-L274)
+
+src/DelegateRegistry.sol#L271-L275
 
 
 ## solc-version
 Impact: Informational
 Confidence: High
- - [ ] ID-9
+ - [ ] ID-11
 Pragma version[>=0.8.13](src/IDelegateRegistry.sol#L2) allows old versions
 
 src/IDelegateRegistry.sol#L2
 
 
- - [ ] ID-10
+ - [ ] ID-12
 Pragma version[^0.8.20](src/examples/Airdrop.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/examples/Airdrop.sol#L2
 
 
- - [ ] ID-11
+ - [ ] ID-13
 solc-0.8.20 is not recommended for deployment
 
- - [ ] ID-12
+ - [ ] ID-14
 Pragma version[^0.8.20](src/tools/RegistryHarness.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/tools/RegistryHarness.sol#L2
 
 
- - [ ] ID-13
+ - [ ] ID-15
 Pragma version[^0.8.20](src/examples/IPLicenseCheck.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/examples/IPLicenseCheck.sol#L2
 
 
- - [ ] ID-14
+ - [ ] ID-16
 Pragma version[^0.8.20](src/DelegateRegistry.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/DelegateRegistry.sol#L2
 
 
- - [ ] ID-15
+ - [ ] ID-17
 Pragma version[^0.8.20](src/examples/DelegateClaim.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/examples/DelegateClaim.sol#L2
@@ -125,10 +139,10 @@ src/examples/DelegateClaim.sol#L2
 ## low-level-calls
 Impact: Informational
 Confidence: High
- - [ ] ID-16
-Low level call in [DelegateRegistry.multicall(bytes[])](src/DelegateRegistry.sol#L42-L51):
-	- [(success,results[i]) = address(this).delegatecall(data[i])](src/DelegateRegistry.sol#L47)
+ - [ ] ID-18
+Low level call in [DelegateRegistry.multicall(bytes[])](src/DelegateRegistry.sol#L34-L43):
+	- [(success,results[i]) = address(this).delegatecall(data[i])](src/DelegateRegistry.sol#L39)
 
-src/DelegateRegistry.sol#L42-L51
+src/DelegateRegistry.sol#L34-L43
 
 

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.20;
 
 import {IDelegateRegistry} from "./IDelegateRegistry.sol";
 
+import {RegistryHashes} from "./libraries/RegistryHashes.sol";
+
 /**
  * @title DelegateRegistry
  * @custom:version 2.0
@@ -19,16 +21,6 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @dev Delegate delegation enumeration inbox, for pushing new hashes only
     mapping(address to => bytes32[] delegationHashes) internal incomingDelegationHashes;
-
-    /// @dev Standardizes storage positions of delegation data
-    enum StoragePositions {
-        to,
-        from,
-        rights,
-        contract_,
-        tokenId,
-        amount
-    }
 
     /// @dev Standardizes from storage flags to prevent double-writes in the delegation in/outbox if the same delegation is revoked and rewritten
     address internal constant DELEGATION_EMPTY = address(0);
@@ -51,9 +43,9 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @inheritdoc IDelegateRegistry
-    function delegateAll(address to, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeHashForAll(to, rights, msg.sender);
-        bytes32 location = _computeLocation(hash);
+    function delegateAll(address to, bytes32 rights, bool enable) external override returns (bytes32 hash) {
+        hash = RegistryHashes._computeAll(to, rights, msg.sender);
+        bytes32 location = RegistryHashes._computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.to, to);
@@ -68,9 +60,9 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @inheritdoc IDelegateRegistry
-    function delegateContract(address to, address contract_, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeHashForContract(contract_, to, rights, msg.sender);
-        bytes32 location = _computeLocation(hash);
+    function delegateContract(address to, address contract_, bytes32 rights, bool enable) external override returns (bytes32 hash) {
+        hash = RegistryHashes._computeContract(contract_, to, rights, msg.sender);
+        bytes32 location = RegistryHashes._computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
@@ -87,9 +79,9 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @inheritdoc IDelegateRegistry
-    function delegateERC721(address to, address contract_, uint256 tokenId, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeHashForERC721(contract_, to, rights, tokenId, msg.sender);
-        bytes32 location = _computeLocation(hash);
+    function delegateERC721(address to, address contract_, uint256 tokenId, bytes32 rights, bool enable) external override returns (bytes32 hash) {
+        hash = RegistryHashes._computeERC721(contract_, to, rights, tokenId, msg.sender);
+        bytes32 location = RegistryHashes._computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
@@ -108,9 +100,9 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     // @inheritdoc IDelegateRegistry
-    function delegateERC20(address to, address contract_, uint256 amount, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeHashForERC20(contract_, to, rights, msg.sender);
-        bytes32 location = _computeLocation(hash);
+    function delegateERC20(address to, address contract_, uint256 amount, bytes32 rights, bool enable) external override returns (bytes32 hash) {
+        hash = RegistryHashes._computeERC20(contract_, to, rights, msg.sender);
+        bytes32 location = RegistryHashes._computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
@@ -132,9 +124,9 @@ contract DelegateRegistry is IDelegateRegistry {
      * @inheritdoc IDelegateRegistry
      * @dev The actual amount is not encoded in the hash, just the existence of a amount (since it is an upper bound)
      */
-    function delegateERC1155(address to, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external override {
-        bytes32 hash = _computeHashForERC1155(contract_, to, rights, tokenId, msg.sender);
-        bytes32 location = _computeLocation(hash);
+    function delegateERC1155(address to, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external override returns (bytes32 hash) {
+        hash = RegistryHashes._computeERC1155(contract_, to, rights, tokenId, msg.sender);
+        bytes32 location = RegistryHashes._computeLocation(hash);
         if (_loadDelegationAddress(location, StoragePositions.from) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
             _writeDelegation(location, StoragePositions.contract_, contract_);
@@ -160,44 +152,44 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForAll(address to, address from, bytes32 rights) external view override returns (bool valid) {
-        valid = _validateDelegation(_computeLocation(_computeHashForAll(to, "", from)), from);
-        if (rights != "" && !valid) valid = _validateDelegation(_computeLocation(_computeHashForAll(to, rights, from)), from);
+        valid = _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, "", from)), from);
+        if (rights != "" && !valid) valid = _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, rights, from)), from);
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForContract(address to, address from, address contract_, bytes32 rights) external view override returns (bool valid) {
-        valid = _validateDelegation(_computeLocation(_computeHashForAll(to, "", from)), from)
-            || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, "", from)), from);
+        valid = _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, "", from)), from)
+            || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeContract(contract_, to, "", from)), from);
         if (rights != "" && !valid) {
-            valid = _validateDelegation(_computeLocation(_computeHashForAll(to, rights, from)), from)
-                || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, rights, from)), from);
+            valid = _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, rights, from)), from)
+                || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeContract(contract_, to, rights, from)), from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForERC721(address to, address from, address contract_, uint256 tokenId, bytes32 rights) external view override returns (bool valid) {
-        valid = _validateDelegation(_computeLocation(_computeHashForAll(to, "", from)), from)
-            || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, "", from)), from)
-            || _validateDelegation(_computeLocation(_computeHashForERC721(contract_, to, "", tokenId, from)), from);
+        valid = _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, "", from)), from)
+            || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeContract(contract_, to, "", from)), from)
+            || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeERC721(contract_, to, "", tokenId, from)), from);
         if (rights != "" && !valid) {
-            valid = _validateDelegation(_computeLocation(_computeHashForAll(to, rights, from)), from)
-                || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, rights, from)), from)
-                || _validateDelegation(_computeLocation(_computeHashForERC721(contract_, to, rights, tokenId, from)), from);
+            valid = _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, rights, from)), from)
+                || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeContract(contract_, to, rights, from)), from)
+                || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeERC721(contract_, to, rights, tokenId, from)), from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForERC20(address to, address from, address contract_, bytes32 rights) external view override returns (uint256 amount) {
-        bytes32 location = _computeLocation(_computeHashForERC20(contract_, to, "", from));
+        bytes32 location = RegistryHashes._computeLocation(RegistryHashes._computeERC20(contract_, to, "", from));
         amount = (
-            _validateDelegation(_computeLocation(_computeHashForAll(to, "", from)), from)
-                || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, "", from)), from)
+            _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, "", from)), from)
+                || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeContract(contract_, to, "", from)), from)
         ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
         if (rights != "" && amount != type(uint256).max) {
-            location = _computeLocation(_computeHashForERC20(contract_, to, rights, from));
+            location = RegistryHashes._computeLocation(RegistryHashes._computeERC20(contract_, to, rights, from));
             uint256 rightsBalance = (
-                _validateDelegation(_computeLocation(_computeHashForAll(to, rights, from)), from)
-                    || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, rights, from)), from)
+                _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, rights, from)), from)
+                    || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeContract(contract_, to, rights, from)), from)
             ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
             amount = rightsBalance > amount ? rightsBalance : amount;
         }
@@ -205,16 +197,16 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForERC1155(address to, address from, address contract_, uint256 tokenId, bytes32 rights) external view override returns (uint256 amount) {
-        bytes32 location = _computeLocation(_computeHashForERC1155(contract_, to, "", tokenId, from));
+        bytes32 location = RegistryHashes._computeLocation(RegistryHashes._computeERC1155(contract_, to, "", tokenId, from));
         amount = (
-            _validateDelegation(_computeLocation(_computeHashForAll(to, "", from)), from)
-                || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, "", from)), from)
+            _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, "", from)), from)
+                || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeContract(contract_, to, "", from)), from)
         ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
         if (rights != "" && amount != type(uint256).max) {
-            location = _computeLocation(_computeHashForERC1155(contract_, to, rights, tokenId, from));
+            location = RegistryHashes._computeLocation(RegistryHashes._computeERC1155(contract_, to, rights, tokenId, from));
             uint256 rightsBalance = (
-                _validateDelegation(_computeLocation(_computeHashForAll(to, rights, from)), from)
-                    || _validateDelegation(_computeLocation(_computeHashForContract(contract_, to, rights, from)), from)
+                _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeAll(to, rights, from)), from)
+                    || _validateDelegation(RegistryHashes._computeLocation(RegistryHashes._computeContract(contract_, to, rights, from)), from)
             ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
             amount = rightsBalance > amount ? rightsBalance : amount;
         }
@@ -251,13 +243,13 @@ contract DelegateRegistry is IDelegateRegistry {
         address from;
         unchecked {
             for (uint256 i = 0; i < hashes.length; ++i) {
-                location = _computeLocation(hashes[i]);
+                location = RegistryHashes._computeLocation(hashes[i]);
                 from = _loadDelegationAddress(location, StoragePositions.from);
                 if (from == DELEGATION_EMPTY || from == DELEGATION_REVOKED) {
                     delegations_[i] = Delegation({type_: DelegationType.NONE, to: address(0), from: address(0), rights: "", amount: 0, contract_: address(0), tokenId: 0});
                 } else {
                     delegations_[i] = Delegation({
-                        type_: _decodeLastByteToType(hashes[i]),
+                        type_: RegistryHashes._decodeLastByteToType(hashes[i]),
                         to: _loadDelegationAddress(location, StoragePositions.to),
                         from: from,
                         rights: _loadDelegationBytes32(location, StoragePositions.rights),
@@ -271,6 +263,26 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /**
+     * ----------- EXTERNAL STORAGE ACCESS -----------
+     */
+
+    // WEN EXTSLOAD :(
+
+    function readSlot(bytes32 location) external view returns (bytes32 contents) {
+        assembly {
+            contents := sload(location)
+        }
+    }
+
+    function readSlots(bytes32[] calldata locations) external view returns (bytes32[] memory contents) {
+        uint256 length = locations.length;
+        contents = new bytes32[](length);
+        assembly {
+            for { let i := 0 } lt(i, length) { i := add(i, 1) } { mstore(add(contents, mul(add(i, 1), 32)), sload(calldataload(add(68, mul(i, 32))))) }
+        }
+    }
+
+    /**
      * ----------- ERC165 -----------
      */
 
@@ -279,50 +291,6 @@ contract DelegateRegistry is IDelegateRegistry {
     /// @return valid Whether the queried interface is supported
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
         return interfaceId == type(IDelegateRegistry).interfaceId || interfaceId == 0x01ffc9a7;
-    }
-
-    /**
-     * ----------- INTERNAL -----------
-     */
-
-    /// @dev Helper function to compute delegation hash for all delegation
-    function _computeHashForAll(address to, bytes32 rights, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(to, rights, from)), DelegationType.ALL);
-    }
-
-    /// @dev Helper function to compute delegation hash for contract delegation
-    function _computeHashForContract(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), DelegationType.CONTRACT);
-    }
-
-    /// @dev Helper function to compute delegation hash for ERC721 delegation
-    function _computeHashForERC721(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), DelegationType.ERC721);
-    }
-
-    /// @dev Helper function to compute delegation hash for ERC20 delegation
-    function _computeHashForERC20(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), DelegationType.ERC20);
-    }
-
-    /// @dev Helper function to compute delegation hash for ERC1155 delegation
-    function _computeHashForERC1155(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), DelegationType.ERC1155);
-    }
-
-    /// @dev Helper function to encode the last byte of a delegation hash to its type
-    function _encodeLastByteWithType(bytes32 _input, DelegationType _type) internal pure returns (bytes32) {
-        return (_input & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00) | bytes32(uint256(_type));
-    }
-
-    /// @dev Helper function to decode last byte of a delegation hash to obtain its type
-    function _decodeLastByteToType(bytes32 _input) internal pure returns (DelegationType) {
-        return DelegationType(uint8(uint256(_input) & 0xFF));
-    }
-
-    /// @dev Helper function that computes the data location of a particular delegation hash
-    function _computeLocation(bytes32 hash) internal pure returns (bytes32 location) {
-        location = keccak256(abi.encode(hash, 0)); // delegations mapping is at slot 0
     }
 
     /**
@@ -365,17 +333,17 @@ contract DelegateRegistry is IDelegateRegistry {
         unchecked {
             for (uint256 i = 0; i < hashesLength; ++i) {
                 hash = hashes[i];
-                if (_loadDelegationAddress(_computeLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) filteredHashes[count++] = hash;
+                if (_loadDelegationAddress(RegistryHashes._computeLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) filteredHashes[count++] = hash;
             }
             delegations_ = new Delegation[](count);
             bytes32 location;
             address from;
             for (uint256 i = 0; i < count; ++i) {
                 hash = filteredHashes[i];
-                location = _computeLocation(hash);
+                location = RegistryHashes._computeLocation(hash);
                 from = _loadDelegationAddress(location, StoragePositions.from);
                 delegations_[i] = Delegation({
-                    type_: _decodeLastByteToType(hash),
+                    type_: RegistryHashes._decodeLastByteToType(hash),
                     to: _loadDelegationAddress(location, StoragePositions.to),
                     from: from,
                     rights: _loadDelegationBytes32(location, StoragePositions.rights),
@@ -396,7 +364,7 @@ contract DelegateRegistry is IDelegateRegistry {
         unchecked {
             for (uint256 i = 0; i < hashesLength; ++i) {
                 hash = hashes[i];
-                if (_loadDelegationAddress(_computeLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) filteredHashes[count++] = hash;
+                if (_loadDelegationAddress(RegistryHashes._computeLocation(hash), StoragePositions.from) > DELEGATION_REVOKED) filteredHashes[count++] = hash;
             }
             validHashes = new bytes32[](count);
             for (uint256 i = 0; i < count; ++i) {

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -63,8 +63,9 @@ interface IDelegateRegistry {
      * @param to The address to act as delegate
      * @param rights Specific subdelegation rights granted to the delegate, pass an empty bytestring to encompass all rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
+     * @return delegationHash the unique identifier of the delegation
      */
-    function delegateAll(address to, bytes32 rights, bool enable) external;
+    function delegateAll(address to, bytes32 rights, bool enable) external returns (bytes32 delegationHash);
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for a specific contract
@@ -72,8 +73,9 @@ interface IDelegateRegistry {
      * @param contract_ The contract whose rights are being delegated
      * @param rights Specific subdelegation rights granted to the delegate, pass an empty bytestring to encompass all rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
+     * @return delegationHash the unique identifier of the delegation
      */
-    function delegateContract(address to, address contract_, bytes32 rights, bool enable) external;
+    function delegateContract(address to, address contract_, bytes32 rights, bool enable) external returns (bytes32 delegationHash);
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for a specific ERC721 token
@@ -82,8 +84,9 @@ interface IDelegateRegistry {
      * @param tokenId The token id to delegate
      * @param rights Specific subdelegation rights granted to the delegate, pass an empty bytestring to encompass all rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
+     * @return delegationHash the unique identifier of the delegation
      */
-    function delegateERC721(address to, address contract_, uint256 tokenId, bytes32 rights, bool enable) external;
+    function delegateERC721(address to, address contract_, uint256 tokenId, bytes32 rights, bool enable) external returns (bytes32 delegationHash);
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for a specific amount of ERC20 tokens
@@ -92,8 +95,9 @@ interface IDelegateRegistry {
      * @param amount The amount to delegate
      * @param rights Specific subdelegation rights granted to the delegate, pass an empty bytestring to encompass all rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
+     * @return delegationHash the unique identifier of the delegation
      */
-    function delegateERC20(address to, address contract_, uint256 amount, bytes32 rights, bool enable) external;
+    function delegateERC20(address to, address contract_, uint256 amount, bytes32 rights, bool enable) external returns (bytes32 delegationHash);
 
     /**
      * @notice Allow the delegate to act on behalf of `msg.sender` for a specific amount of ERC1155 tokens
@@ -103,8 +107,9 @@ interface IDelegateRegistry {
      * @param amount The amount of that token id to delegate
      * @param rights Specific subdelegation rights granted to the delegate, pass an empty bytestring to encompass all rights
      * @param enable Whether to enable or disable this delegation, true delegates and false revokes
+     * @return delegationHash the unique identifier of the delegation
      */
-    function delegateERC1155(address to, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external;
+    function delegateERC1155(address to, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external returns (bytes32 delegationHash);
 
     /**
      * ----------- CHECKS -----------
@@ -199,4 +204,27 @@ interface IDelegateRegistry {
      * @return delegations Array of Delegation structs, return empty structs for nonexistent or revoked delegations
      */
     function getDelegationsFromHashes(bytes32[] calldata delegationHashes) external view returns (Delegation[] memory delegations);
+
+    /**
+     * ----------- STORAGE ACCESS -----------
+     */
+    /// @dev Standardizes storage positions of delegation data
+    enum StoragePositions {
+        to,
+        from,
+        rights,
+        contract_,
+        tokenId,
+        amount
+    }
+
+    /**
+     * @notice allows external contract to read arbitrary storage slot
+     */
+    function readSlot(bytes32 location) external view returns (bytes32);
+
+    /**
+     * @notice allows external contracts to read an arbitrary array of storage slots
+     */
+    function readSlots(bytes32[] calldata locations) external view returns (bytes32[] memory);
 }

--- a/src/libraries/RegistryHashes.sol
+++ b/src/libraries/RegistryHashes.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import {IDelegateRegistry} from "../IDelegateRegistry.sol";
+
+library RegistryHashes {
+    /// @dev Helper function to compute delegation hash for all delegation
+    function _computeAll(address to, bytes32 rights, address from) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(to, rights, from)), IDelegateRegistry.DelegationType.ALL);
+    }
+
+    /// @dev Helper function to compute delegation hash for contract delegation
+    function _computeContract(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), IDelegateRegistry.DelegationType.CONTRACT);
+    }
+
+    /// @dev Helper function to compute delegation hash for ERC721 delegation
+    function _computeERC721(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), IDelegateRegistry.DelegationType.ERC721);
+    }
+
+    /// @dev Helper function to compute delegation hash for ERC20 delegation
+    function _computeERC20(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), IDelegateRegistry.DelegationType.ERC20);
+    }
+
+    /// @dev Helper function to compute delegation hash for ERC1155 delegation
+    function _computeERC1155(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), IDelegateRegistry.DelegationType.ERC1155);
+    }
+
+    /// @dev Helper function to encode the last byte of a delegation hash to its type
+    function _encodeLastByteWithType(bytes32 _input, IDelegateRegistry.DelegationType _type) internal pure returns (bytes32) {
+        return (_input & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00) | bytes32(uint256(_type));
+    }
+
+    /// @dev Helper function to decode last byte of a delegation hash to obtain its type
+    function _decodeLastByteToType(bytes32 _input) internal pure returns (IDelegateRegistry.DelegationType) {
+        return IDelegateRegistry.DelegationType(uint8(uint256(_input) & 0xFF));
+    }
+
+    /// @dev Helper function that computes the data location of a particular delegation hash
+    function _computeLocation(bytes32 hash) internal pure returns (bytes32 location) {
+        location = keccak256(abi.encode(hash, 0)); // delegations mapping is at slot 0
+    }
+}

--- a/src/tools/RegistryHarness.sol
+++ b/src/tools/RegistryHarness.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.20;
 
 import {DelegateRegistry} from "src/DelegateRegistry.sol";
 
+import {RegistryHashes} from "../libraries/RegistryHashes.sol";
+
 /// @dev harness contract that exposes internal registry methods as external ones
 contract RegistryHarness is DelegateRegistry {
     constructor() {
@@ -22,34 +24,34 @@ contract RegistryHarness is DelegateRegistry {
     }
 
     function exposedComputeHashForAll(address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return _computeHashForAll(delegate, rights, vault);
+        return RegistryHashes._computeAll(delegate, rights, vault);
     }
 
     function exposedComputeHashForContract(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return _computeHashForContract(contract_, delegate, rights, vault);
+        return RegistryHashes._computeContract(contract_, delegate, rights, vault);
     }
 
     function exposedComputeHashForERC721(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault) external pure returns (bytes32) {
-        return _computeHashForERC721(contract_, delegate, rights, tokenId, vault);
+        return RegistryHashes._computeERC721(contract_, delegate, rights, tokenId, vault);
     }
 
     function exposedComputeHashForERC20(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return _computeHashForERC20(contract_, delegate, rights, vault);
+        return RegistryHashes._computeERC20(contract_, delegate, rights, vault);
     }
 
     function exposedComputeHashForERC1155(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault) external pure returns (bytes32) {
-        return _computeHashForERC1155(contract_, delegate, rights, tokenId, vault);
+        return RegistryHashes._computeERC1155(contract_, delegate, rights, tokenId, vault);
     }
 
     function exposedEncodeLastByteWithType(bytes32 input, DelegationType type_) external pure returns (bytes32) {
-        return _encodeLastByteWithType(input, type_);
+        return RegistryHashes._encodeLastByteWithType(input, type_);
     }
 
     function exposedDecodeLastByteToType(bytes32 input) external pure returns (DelegationType) {
-        return _decodeLastByteToType(input);
+        return RegistryHashes._decodeLastByteToType(input);
     }
 
     function exposedComputeLocation(bytes32 hash) external pure returns (bytes32 location) {
-        return _computeLocation(hash);
+        return RegistryHashes._computeLocation(hash);
     }
 }

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -630,4 +630,28 @@ contract RegistryUnitTests is Test {
         vm.stopPrank();
         assertEq(registry.checkDelegateForERC1155(delegate, vault, contract_, tokenId, rights), 0);
     }
+
+    /**
+     * ----------- storage access -----------
+     */
+
+    function testReadSlot(bytes32 slot, bytes32 data) public {
+        registry = new Registry();
+        vm.store(address(registry), slot, data);
+        assertEq(data, registry.readSlot(slot));
+    }
+
+    function testReadSlots(uint256 slotSeed, bytes32[] calldata data) public {
+        registry = new Registry();
+        bytes32[] memory slots = new bytes32[](data.length);
+        for (uint256 i = 0; i < data.length; i++) {
+            slots[i] = keccak256(abi.encode(slotSeed, i));
+            vm.store(address(registry), slots[i], data[i]);
+        }
+        bytes32[] memory receivedData = registry.readSlots(slots);
+        assertEq(receivedData.length, data.length);
+        for (uint256 i = 0; i < data.length; i++) {
+            assertEq(receivedData[i], data[i]);
+        }
+    }
 }

--- a/test/examples/IPLicenseCheck.t.sol
+++ b/test/examples/IPLicenseCheck.t.sol
@@ -38,7 +38,8 @@ contract IPLicenseCheckTest is Test {
         // Check false if vault doesn't own NFT
         assertFalse(ipLicenseCheck.checkForIPLicense(wallet, fVault, address(nft), 1, ipLicense));
         // Check false if wallet has a different license
-        assertFalse(ipLicenseCheck.checkForIPLicense(wallet, vault, address(nft), 1, fIpLicense));
+        if (ipLicense != "") assertFalse(ipLicenseCheck.checkForIPLicense(wallet, vault, address(nft), 1, fIpLicense));
+        else assertTrue(ipLicenseCheck.checkForIPLicense(wallet, vault, address(nft), 1, fIpLicense));
         // Check true if vault has nft and wallet has license
         assertTrue(ipLicenseCheck.checkForIPLicense(wallet, vault, address(nft), 1, ipLicense));
     }
@@ -68,7 +69,8 @@ contract IPLicenseCheckTest is Test {
         // Check false if licensor doesn't have licensor rights
         assertFalse(ipLicenseCheck.checkForIPLicenseFromLicensor(wallet, fLicensor, vault, address(nft), 1, ipLicense));
         // Check false if wallet has a different license
-        assertFalse(ipLicenseCheck.checkForIPLicenseFromLicensor(wallet, licensor, vault, address(nft), 1, fIpLicense));
+        if (ipLicense != "") assertFalse(ipLicenseCheck.checkForIPLicenseFromLicensor(wallet, licensor, vault, address(nft), 1, fIpLicense));
+        else assertTrue(ipLicenseCheck.checkForIPLicenseFromLicensor(wallet, licensor, vault, address(nft), 1, fIpLicense));
         // Check true if vault has nft, licensor has licensor rights, and wallet has license
         assertTrue(ipLicenseCheck.checkForIPLicenseFromLicensor(wallet, licensor, vault, address(nft), 1, ipLicense));
     }


### PR DESCRIPTION
- All delegate methods now return the hash of the related delegation.
- Internal pure methods related to registry hashes have been moved to `RegistryHashes` library
- `StoragePositions` enum moved to interface for easy access
-  Two external storage access methods added. An arbitrary slot read method `readSlot(bytes32)`, and a vectorized version of this `readSlots(bytes32[])`.
- Unit test for new storage access methods added.
- Added script to slither action to check report summary for medium and high severity in summary since --fail-medium config no longer supported.