### PR TITLE
10-17% Gas reduction for checks, hash tests

### DIFF
--- a/.github/workflows/slither-report.yml
+++ b/.github/workflows/slither-report.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check slither report
         run: |
           section=$(awk '/^##/{exit} {print}' slitherReport.md)
-          if [[ $section == *"Medium"* || $section == *"High"* ]]; then
-            echo "Medium or High risk found in slither report. Failing the run."
+          if [[ $section == *"Medium"* || $section == *"High"* || $section == *"Low"* ]]; then
+            echo "Low, Medium or High risk found in slither report. Failing the run."
             exit 1
           fi

--- a/gasbenchmark10mil
+++ b/gasbenchmark10mil
@@ -1,16 +1,16 @@
 | src/DelegateRegistry.sol:DelegateRegistry contract |                 |        |        |        |         |
 |----------------------------------------------------|-----------------|--------|--------|--------|---------|
 | Deployment Cost                                    | Deployment Size |        |        |        |         |
-| 1840741                                            | 9226            |        |        |        |         |
+| 2124658                                            | 10644           |        |        |        |         |
 | Function Name                                      | min             | avg    | median | max    | # calls |
-| checkDelegateForAll                                | 3293            | 3648   | 3648   | 4004   | 2       |
-| checkDelegateForContract                           | 6120            | 6856   | 6856   | 7593   | 2       |
-| checkDelegateForERC1155                            | 8989            | 10164  | 10164  | 11340  | 2       |
-| checkDelegateForERC20                              | 8899            | 10053  | 10053  | 11207  | 2       |
-| checkDelegateForERC721                             | 8981            | 10114  | 10114  | 11248  | 2       |
-| delegateAll                                        | 136182          | 136182 | 136182 | 136182 | 2       |
-| delegateContract                                   | 114804          | 125754 | 125754 | 136704 | 2       |
-| delegateERC1155                                    | 159739          | 170689 | 170689 | 181639 | 2       |
-| delegateERC20                                      | 137269          | 148219 | 148219 | 159169 | 2       |
-| delegateERC721                                     | 137279          | 148229 | 148229 | 159179 | 2       |
-| multicall                                          | 691368          | 691368 | 691368 | 691368 | 1       |
+| checkDelegateForAll                                | 2980            | 3183   | 3183   | 3386   | 2       |
+| checkDelegateForContract                           | 5473            | 5895   | 5895   | 6317   | 2       |
+| checkDelegateForERC1155                            | 7990            | 8685   | 8685   | 9380   | 2       |
+| checkDelegateForERC20                              | 7927            | 8610   | 8610   | 9293   | 2       |
+| checkDelegateForERC721                             | 7991            | 8644   | 8644   | 9297   | 2       |
+| delegateAll                                        | 135861          | 135861 | 135861 | 135861 | 2       |
+| delegateContract                                   | 114469          | 125419 | 125419 | 136369 | 2       |
+| delegateERC1155                                    | 159393          | 170343 | 170343 | 181293 | 2       |
+| delegateERC20                                      | 136942          | 147892 | 147892 | 158842 | 2       |
+| delegateERC721                                     | 136936          | 147886 | 147886 | 158836 | 2       |
+| multicall                                          | 689696          | 689696 | 689696 | 689696 | 1       |

--- a/hashbenchmark10mil
+++ b/hashbenchmark10mil
@@ -1,0 +1,18 @@
+| src/tools/HashHarness.sol:HashHarness contract |                 |     |        |     |         |
+|------------------------------------------------|-----------------|-----|--------|-----|---------|
+| Deployment Cost                                | Deployment Size |     |        |     |         |
+| 416655                                         | 2113            |     |        |     |         |
+| Function Name                                  | min             | avg | median | max | # calls |
+| allHash                                        | 634             | 634 | 634    | 634 | 1       |
+| allLocation                                    | 746             | 746 | 746    | 746 | 1       |
+| contractHash                                   | 835             | 835 | 835    | 835 | 1       |
+| contractLocation                               | 873             | 873 | 873    | 873 | 1       |
+| decodeType                                     | 393             | 393 | 393    | 393 | 1       |
+| encodeType                                     | 351             | 351 | 351    | 351 | 1       |
+| erc1155Hash                                    | 843             | 843 | 843    | 843 | 1       |
+| erc1155Location                                | 876             | 876 | 876    | 876 | 1       |
+| erc20Hash                                      | 814             | 814 | 814    | 814 | 1       |
+| erc20Location                                  | 831             | 831 | 831    | 831 | 1       |
+| erc721Hash                                     | 821             | 821 | 821    | 821 | 1       |
+| erc721Location                                 | 910             | 910 | 910    | 910 | 1       |
+| location                                       | 406             | 406 | 406    | 406 | 1       |

--- a/slitherReport.md
+++ b/slitherReport.md
@@ -1,72 +1,72 @@
 **THIS CHECKLIST IS NOT COMPLETE**. Use `--show-ignored-findings` to show all the results.
 Summary
  - [assembly](#assembly) (9 results) (Informational)
- - [solc-version](#solc-version) (7 results) (Informational)
+ - [solc-version](#solc-version) (8 results) (Informational)
  - [low-level-calls](#low-level-calls) (1 results) (Informational)
 ## assembly
 Impact: Informational
 Confidence: High
  - [ ] ID-0
-[DelegateRegistry.readSlot(bytes32)](src/DelegateRegistry.sol#L254-L258) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L255-L257)
+[DelegateRegistry.readSlots(bytes32[])](src/DelegateRegistry.sol#L255-L261) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L258-L260)
 
-src/DelegateRegistry.sol#L254-L258
+src/DelegateRegistry.sol#L255-L261
 
 
  - [ ] ID-1
-[DelegateRegistry._loadDelegationAddresses(bytes32,IDelegateRegistry.StoragePositions,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L383-L396) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L388-L395)
+[DelegateRegistry._loadDelegationBytes32(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L357-L361) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L358-L360)
 
-src/DelegateRegistry.sol#L383-L396
+src/DelegateRegistry.sol#L357-L361
 
 
  - [ ] ID-2
-[DelegateRegistry._loadDelegationUint(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L369-L373) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L370-L372)
+[DelegateRegistry._loadDelegationUint(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L364-L368) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L365-L367)
 
-src/DelegateRegistry.sol#L369-L373
+src/DelegateRegistry.sol#L364-L368
 
 
  - [ ] ID-3
-[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,uint256)](src/DelegateRegistry.sol#L297-L301) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L298-L300)
+[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,uint256)](src/DelegateRegistry.sol#L292-L296) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L293-L295)
 
-src/DelegateRegistry.sol#L297-L301
+src/DelegateRegistry.sol#L292-L296
 
 
  - [ ] ID-4
-[DelegateRegistry._loadDelegationBytes32(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L362-L366) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L363-L365)
+[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,bytes32)](src/DelegateRegistry.sol#L285-L289) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L286-L288)
 
-src/DelegateRegistry.sol#L362-L366
+src/DelegateRegistry.sol#L285-L289
 
 
  - [ ] ID-5
-[DelegateRegistry.readSlots(bytes32[])](src/DelegateRegistry.sol#L260-L266) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L263-L265)
+[DelegateRegistry._writeDelegationAddresses(bytes32,IDelegateRegistry.StoragePositions,IDelegateRegistry.StoragePositions,address,address,address)](src/DelegateRegistry.sol#L299-L306) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L302-L305)
 
-src/DelegateRegistry.sol#L260-L266
+src/DelegateRegistry.sol#L299-L306
 
 
  - [ ] ID-6
-[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,bytes32)](src/DelegateRegistry.sol#L290-L294) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L291-L293)
+[DelegateRegistry._loadFrom(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L371-L375) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L372-L374)
 
-src/DelegateRegistry.sol#L290-L294
+src/DelegateRegistry.sol#L371-L375
 
 
  - [ ] ID-7
-[DelegateRegistry._writeDelegationAddresses(bytes32,IDelegateRegistry.StoragePositions,IDelegateRegistry.StoragePositions,address,address,address)](src/DelegateRegistry.sol#L304-L311) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L307-L310)
+[DelegateRegistry._loadDelegationAddresses(bytes32,IDelegateRegistry.StoragePositions,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L378-L391) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L383-L390)
 
-src/DelegateRegistry.sol#L304-L311
+src/DelegateRegistry.sol#L378-L391
 
 
  - [ ] ID-8
-[DelegateRegistry._loadFrom(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L376-L380) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L377-L379)
+[DelegateRegistry.readSlot(bytes32)](src/DelegateRegistry.sol#L249-L253) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L250-L252)
 
-src/DelegateRegistry.sol#L376-L380
+src/DelegateRegistry.sol#L249-L253
 
 
 ## solc-version
@@ -79,33 +79,39 @@ src/IDelegateRegistry.sol#L2
 
 
  - [ ] ID-10
+Pragma version[^0.8.20](src/tools/HashHarness.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
+
+src/tools/HashHarness.sol#L2
+
+
+ - [ ] ID-11
 Pragma version[^0.8.20](src/examples/Airdrop.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/examples/Airdrop.sol#L2
 
 
- - [ ] ID-11
+ - [ ] ID-12
 solc-0.8.20 is not recommended for deployment
 
- - [ ] ID-12
+ - [ ] ID-13
 Pragma version[^0.8.20](src/tools/RegistryHarness.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/tools/RegistryHarness.sol#L2
 
 
- - [ ] ID-13
+ - [ ] ID-14
 Pragma version[^0.8.20](src/examples/IPLicenseCheck.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/examples/IPLicenseCheck.sol#L2
 
 
- - [ ] ID-14
+ - [ ] ID-15
 Pragma version[^0.8.20](src/DelegateRegistry.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/DelegateRegistry.sol#L2
 
 
- - [ ] ID-15
+ - [ ] ID-16
 Pragma version[^0.8.20](src/examples/DelegateClaim.sol#L2) necessitates a version too recent to be trusted. Consider deploying with 0.8.18.
 
 src/examples/DelegateClaim.sol#L2
@@ -114,10 +120,10 @@ src/examples/DelegateClaim.sol#L2
 ## low-level-calls
 Impact: Informational
 Confidence: High
- - [ ] ID-16
-Low level call in [DelegateRegistry.multicall(bytes[])](src/DelegateRegistry.sol#L34-L45):
-	- [(success,results[i]) = address(this).delegatecall(data[i])](src/DelegateRegistry.sol#L41)
+ - [ ] ID-17
+Low level call in [DelegateRegistry.multicall(bytes[])](src/DelegateRegistry.sol#L34-L44):
+	- [(success,results[i]) = address(this).delegatecall(data[i])](src/DelegateRegistry.sol#L40)
 
-src/DelegateRegistry.sol#L34-L45
+src/DelegateRegistry.sol#L34-L44
 
 

--- a/src/libraries/RegistryHashes.sol
+++ b/src/libraries/RegistryHashes.sol
@@ -3,44 +3,304 @@ pragma solidity ^0.8.20;
 
 import {IDelegateRegistry} from "../IDelegateRegistry.sol";
 
+/**
+ * @title Library for calculating the hashes and storage locations used in the delegate registry
+ *
+ * The encoding for the 5 types of delegate registry hashes should be as follows
+ *
+ * ALL:         keccak256(abi.encode(from, rights, to))
+ * CONTRACT:    keccak256(abi.encode(from, rights, to, contract_))
+ * ERC721:      keccak256(abi.encode(from, rights, to, tokenId, contract_))
+ * ERC20:       keccak256(abi.encode(from, rights, to, contract_))
+ * ERC1155:     keccak256(abi.encode(from, rights, to, tokenId, contract_))
+ *
+ * To avoid collisions between the hashes with respect to type, the last byte of the hash is encoded with a unique number representing the type of delegation.
+ *
+ */
 library RegistryHashes {
-    /// @dev Helper function to compute delegation hash for all delegation
-    function _computeAll(address to, bytes32 rights, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(to, rights, from)), IDelegateRegistry.DelegationType.ALL);
+    /// @dev Used to delete the last byte of a 32 byte word with and(word, deleteLastByte)
+    bytes32 internal constant deleteLastByte = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00;
+    /// @dev Used to clean address types of dirty bits with and(address, cleanAddress)
+    bytes32 internal constant cleanAddress = 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff;
+    /// @dev Used to delete everything but the last byte of a 32 byte word with and(word, extractLastByte)
+    uint256 internal constant extractLastByte = 0xFF;
+    /// @dev uint256 constant for the delegate registry delegation type enumeration, related unit test should fail if these mismatch
+    uint256 internal constant allType = 1;
+    uint256 internal constant contractType = 2;
+    uint256 internal constant erc721Type = 3;
+    uint256 internal constant erc20Type = 4;
+    uint256 internal constant erc1155Type = 5;
+    /// @dev uint256 constant for the location of the delegations array in the delegate registry, assumed to be zero
+    uint256 internal constant delegationSlot = 0;
+
+    /**
+     * @notice Helper function to encode the last byte of a delegation hash with a delegation type
+     * @param inputHash is the hash to encode the type in
+     * @param inputType is the type to encode in the hash
+     * @dev Will not revert for inputType larger than type(IDelegationRegistry.DelegationType).max, and any inputType larger than uint8 will be cleaned to its byte
+     * furthest to the right
+     * @return outputHash is inputHash with its last byte overwritten with the inputType
+     */
+    function encodeType(bytes32 inputHash, uint256 inputType) internal pure returns (bytes32 outputHash) {
+        assembly {
+            outputHash := or(and(inputHash, deleteLastByte), and(inputType, extractLastByte))
+        }
     }
 
-    /// @dev Helper function to compute delegation hash for contract delegation
-    function _computeContract(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), IDelegateRegistry.DelegationType.CONTRACT);
+    /**
+     * @notice Helper function to decode last byte of a delegation hash to obtain its delegation type
+     * @param inputHash to decode the type from
+     * @return decodedType of the delegation
+     * @dev function itself will not revert if decodedType > type(IDelegateRegistry.DelegationType).max
+     * @dev may lead to a revert with Conversion into non-existent enum type after the function is called if inputHash was encoded with type outside the DelegationType
+     * enum range
+     */
+    function decodeType(bytes32 inputHash) internal pure returns (IDelegateRegistry.DelegationType decodedType) {
+        assembly {
+            decodedType := and(inputHash, extractLastByte)
+        }
     }
 
-    /// @dev Helper function to compute delegation hash for ERC721 delegation
-    function _computeERC721(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), IDelegateRegistry.DelegationType.ERC721);
+    /**
+     * @notice Helper function that computes the storage location of a particular delegation array
+     * @param inputHash is the hash of the delegation
+     * @return computedLocation is the storage key of the delegation array at position 0
+     * @dev Storage keys further down the array can be obtained by adding computedLocation with the element position
+     * @dev Follows the solidity storage location encoding for a mapping(bytes32 => fixedArray) at the position of the delegationSlot
+     */
+    function location(bytes32 inputHash) internal pure returns (bytes32 computedLocation) {
+        assembly ("memory-safe") {
+            mstore(0, inputHash) // Store hash in scratch space
+            mstore(32, delegationSlot) // Store delegationSlot after hash in scratch space
+            computedLocation := keccak256(0, 64) // Run keccak256 over bytes in scratch space to obtain the storage key
+        }
     }
 
-    /// @dev Helper function to compute delegation hash for ERC20 delegation
-    function _computeERC20(address contract_, address to, bytes32 rights, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, from)), IDelegateRegistry.DelegationType.ERC20);
+    /**
+     * @notice Helper function to compute delegation hash for all delegation
+     * @param from is the address making the delegation
+     * @param rights it the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @return hash of the delegation parameters encoded with allType
+     * @dev returned hash should be equivalent to keccak256(abi.encode(from, rights, to)) with the last byte overwritten with allType
+     * @dev will not revert if from or to are > uint160, any input larger than uint160 for from and to will be cleaned to their last 20 bytes
+     */
+    function allHash(address from, bytes32 rights, address to) internal pure returns (bytes32 hash) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            hash := or(and(keccak256(ptr, 96), deleteLastByte), allType) // Runs keccak256 on the 96 bytes at ptr, and then encodes the last byte of that hash with
+                // allType
+        }
     }
 
-    /// @dev Helper function to compute delegation hash for ERC1155 delegation
-    function _computeERC1155(address contract_, address to, bytes32 rights, uint256 tokenId, address from) internal pure returns (bytes32) {
-        return _encodeLastByteWithType(keccak256(abi.encode(contract_, to, rights, tokenId, from)), IDelegateRegistry.DelegationType.ERC1155);
+    /**
+     * @notice Helper function to compute delegation location for all delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @return computedLocation is the storage location of the all delegation with those parameters in the delegations mapping
+     * @dev gives the same location hash as location(allHash(from, rights, to)) would
+     * @dev will not revert if from or to are > uint160, any input larger than uint160 for from and to will be cleaned to their last 20 bytes
+     */
+    function allLocation(address from, bytes32 rights, address to) internal pure returns (bytes32 computedLocation) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(ptr, or(and(keccak256(ptr, 96), deleteLastByte), allType)) // Store allHash at ptr location
+            mstore(add(ptr, 32), delegationSlot) // Store delegationSlot after allHash at ptr location
+            computedLocation := keccak256(ptr, 64) // Runs keccak256 on the 64 bytes at ptr to obtain the location
+        }
     }
 
-    /// @dev Helper function to encode the last byte of a delegation hash to its type
-    function _encodeLastByteWithType(bytes32 _input, IDelegateRegistry.DelegationType _type) internal pure returns (bytes32) {
-        return (_input & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00) | bytes32(uint256(_type));
+    /**
+     * @notice Helper function to compute delegation hash for contract delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @param contract_ is the address of the contract specified by the delegation
+     * @return hash of the delegation parameters encoded with contractType
+     * @dev returned hash should be equivalent to keccak256(abi.encode(from, rights, to, contract_)) with the last byte overwritten with contractType
+     * @dev will not revert if from, to, or contract_ are > uint160, any input larger than uint160 for from, to, or contract_ will be cleaned to their last 20 bytes
+     */
+    function contractHash(address from, bytes32 rights, address to, address contract_) internal pure returns (bytes32 hash) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(add(ptr, 96), and(contract_, cleanAddress)) // Cleans and store contract_
+            hash := or(and(keccak256(ptr, 128), deleteLastByte), contractType) // Run keccak256 on the 128 bytes at ptr, and then encodes the last byte of that hash with
+                // contractType
+        }
     }
 
-    /// @dev Helper function to decode last byte of a delegation hash to obtain its type
-    function _decodeLastByteToType(bytes32 _input) internal pure returns (IDelegateRegistry.DelegationType) {
-        return IDelegateRegistry.DelegationType(uint8(uint256(_input) & 0xFF));
+    /**
+     * @notice Helper function to compute delegation location for contract delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @param contract_ is the address of the contract specified by the delegation
+     * @return computedLocation is the storage location of the contract delegation with those parameters in the delegations mapping
+     * @dev gives the same location hash as location(contractHash(from, rights, to, contract_)) would
+     * @dev will not revert if from, to, or contract_ are > uint160, any input larger than uint160 for from, to, or contract_ will be cleaned to their last 20 bytes
+     */
+    function contractLocation(address from, bytes32 rights, address to, address contract_) internal pure returns (bytes32 computedLocation) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(add(ptr, 96), and(contract_, cleanAddress)) // Cleans and store contract_
+            mstore(ptr, or(and(keccak256(ptr, 128), deleteLastByte), contractType)) // Store contractHash
+            mstore(add(ptr, 32), delegationSlot) // Store delegationSlot after hash
+            computedLocation := keccak256(ptr, 64) // Run keccak256 on the 64 bytes at ptr to obtain the location
+        }
     }
 
-    /// @dev Helper function that computes the data location of a particular delegation hash
-    function _computeLocation(bytes32 hash) internal pure returns (bytes32 location) {
-        location = keccak256(abi.encode(hash, 0)); // delegations mapping is at slot 0
+    /**
+     * @notice Helper function to compute delegation hash for ERC721 delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @param tokenId is the id of the token specified by the delegation
+     * @param contract_ is the address of the contract specified by the delegation
+     * @return hash of the parameters encoded with erc721Type
+     * @dev returned hash should be equivalent to keccak256(abi.encode(from, rights, to, tokenId, contract_)) with the last byte overwritten with erc721Type
+     * @dev will not revert if from, to, or contract_ are > uint160, any input larger than uint160 for from, to, or contract_ will be cleaned to their last 20 bytes
+     */
+    function erc721Hash(address from, bytes32 rights, address to, uint256 tokenId, address contract_) internal pure returns (bytes32 hash) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(add(ptr, 96), tokenId) // Stores tokenId
+            mstore(add(ptr, 128), and(contract_, cleanAddress)) // Cleans and store contract_
+            hash := or(and(keccak256(ptr, 160), deleteLastByte), erc721Type) // Run keccak256 on the 160 bytes at ptr, and then encodes the last byte of that hash with
+                // erc721Type
+        }
+    }
+
+    /**
+     * @notice Helper function to compute delegation location for ERC721 delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @param tokenId is the id of the erc721 token
+     * @param contract_ is the address of the erc721 token contract
+     * @return computedLocation is the storage location of the erc721 delegation with those parameters in the delegations mapping
+     * @dev gives the same location hash as location(erc721Hash(from, rights, to, tokenId, contract_)) would
+     * @dev will not revert if from, to, or contract_ are > uint160, any input larger than uint160 for from, to, or contract_ will be cleaned to their last 20 bytes
+     */
+    function erc721Location(address from, bytes32 rights, address to, uint256 tokenId, address contract_) internal pure returns (bytes32 computedLocation) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(add(ptr, 96), tokenId) // Stores tokenId
+            mstore(add(ptr, 128), and(contract_, cleanAddress)) // Cleans and store contract_
+            mstore(ptr, or(and(keccak256(ptr, 160), deleteLastByte), erc721Type)) // Store erc721Hash
+            mstore(add(ptr, 32), delegationSlot) // Stores delegationSlot
+            computedLocation := keccak256(ptr, 64)
+        }
+    }
+
+    /**
+     * @notice Helper function to compute delegation hash for ERC20 delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @param contract_ is the address of the erc20 token contract
+     * @return hash of the parameters encoded with erc20Type
+     * @dev returned hash should be equivalent to keccak256(abi.encode(from, rights, to, contract_)) with the last byte overwritten with erc20Type
+     * @dev will not revert if from, to, or contract_ are > uint160, any input larger than uint160 for from, to, or contract_ will be cleaned to their last 20 bytes
+     */
+    function erc20Hash(address from, bytes32 rights, address to, address contract_) internal pure returns (bytes32 hash) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Stores rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(add(ptr, 96), and(contract_, cleanAddress)) // Cleans and stores contract_
+            hash := or(and(keccak256(ptr, 128), deleteLastByte), erc20Type) // Runs keccak256 on 128 bytes at ptr and encodes that hash with erc20Type
+        }
+    }
+
+    /**
+     * @notice Helper function to compute delegation location for ERC20 delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @param contract_ is the address of the erc20 token contract
+     * @return computedLocation is the storage location of the erc20 delegation with those parameters in the delegations mapping
+     * @dev gives the same location hash as location(erc20Hash(from, rights, to, contract_)) would
+     * @dev will not revert if from, to, or contract_ are > uint160, any input larger than uint160 for from, to, or contract_ will be cleaned to their last 20 bytes
+     */
+    function erc20Location(address from, bytes32 rights, address to, address contract_) internal pure returns (bytes32 computedLocation) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(add(ptr, 96), and(contract_, cleanAddress)) // Cleans and store contract_
+            mstore(ptr, or(and(keccak256(ptr, 128), deleteLastByte), erc20Type)) // Store erc20Hash
+            mstore(add(ptr, 32), delegationSlot) // Store delegationSlot
+            computedLocation := keccak256(ptr, 64) // Runs keccak256 on the 64 bytes at ptr to get the location
+        }
+    }
+
+    /**
+     * @notice Helper function to compute delegation hash for ERC1155 delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @param tokenId is the id of the erc1155 token
+     * @param contract_ is the address of the erc1155 token contract
+     * @return hash of the parameters encoded with erc1155Type
+     * @dev returned hash should be equivalent to keccak256(abi.encode(from, rights, to, tokenId, contract_)) with the last byte overwritten with erc1155Type
+     * @dev will not revert if from, to, or contract_ are > uint160, any input larger than uint160 for from, to, or contract_ will be cleaned to their last 20 bytes
+     */
+    function erc1155Hash(address from, bytes32 rights, address to, uint256 tokenId, address contract_) internal pure returns (bytes32 hash) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(add(ptr, 96), tokenId) // Stores tokenId
+            mstore(add(ptr, 128), and(contract_, cleanAddress)) // Cleans and store contract_
+            hash := or(and(keccak256(ptr, 160), deleteLastByte), erc1155Type) // Runs keccak256 on 160 bytes at ptr and encodes the last byte of that hash with
+                // erc1155Type
+        }
+    }
+
+    /**
+     * @notice Helper function to compute delegation hash for ERC1155 delegation
+     * @param from is the address making the delegation
+     * @param rights is the rights specified by the delegation
+     * @param to is the address receiving the delegation
+     * @param tokenId is the id of the erc1155 token
+     * @param contract_ is the address of the erc1155 token contract
+     * @return computedLocation is the storage location of the erc1155 delegation with those parameters in the delegations mapping
+     * @dev gives the same location hash as location(erc1155Hash(from, rights, to, tokenId, contract_)) would
+     * @dev will not revert if from, to, or contract_ are > uint160, any input larger than uint160 for from, to, or contract_ will be cleaned to their last 20 bytes
+     */
+    function erc1155Location(address from, bytes32 rights, address to, uint256 tokenId, address contract_) internal pure returns (bytes32 computedLocation) {
+        assembly ("memory-safe") {
+            let ptr := mload(0x40) // Set ptr to the free memory location
+            mstore(ptr, and(from, cleanAddress)) // Cleans and stores from
+            mstore(add(ptr, 32), rights) // Store rights
+            mstore(add(ptr, 64), and(to, cleanAddress)) // Cleans and stores to
+            mstore(add(ptr, 96), tokenId) // Stores tokenId
+            mstore(add(ptr, 128), and(contract_, cleanAddress)) // Cleans and store contract_
+            mstore(ptr, or(and(keccak256(ptr, 160), deleteLastByte), erc1155Type)) // Stores erc1155Hash
+            mstore(add(ptr, 32), delegationSlot) // Store delegationSlot
+            computedLocation := keccak256(ptr, 64) // Runs keccak256 on 64 bytes at ptr to obtain the location
+        }
     }
 }

--- a/src/tools/HashHarness.sol
+++ b/src/tools/HashHarness.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import {RegistryHashes} from "src/libraries/RegistryHashes.sol";
+import {IDelegateRegistry} from "src/IDelegateRegistry.sol";
+
+/// @dev Harness that exposes registry hashes library as contract
+contract HashHarness {
+    function encodeType(bytes32 hash, uint256 delegationType) external pure returns (bytes32) {
+        return RegistryHashes.encodeType(hash, delegationType);
+    }
+
+    function decodeType(bytes32 hash) external pure returns (IDelegateRegistry.DelegationType) {
+        return RegistryHashes.decodeType(hash);
+    }
+
+    function location(bytes32 hash) external pure returns (bytes32) {
+        return RegistryHashes.location(hash);
+    }
+
+    function allHash(address from, bytes32 rights, address to) external pure returns (bytes32) {
+        return RegistryHashes.allHash(from, rights, to);
+    }
+
+    function contractHash(address from, bytes32 rights, address to, address contract_) external pure returns (bytes32) {
+        return RegistryHashes.contractHash(from, rights, to, contract_);
+    }
+
+    function erc721Hash(address from, bytes32 rights, address to, uint256 tokenId, address contract_) external pure returns (bytes32) {
+        return RegistryHashes.erc721Hash(from, rights, to, tokenId, contract_);
+    }
+
+    function erc20Hash(address from, bytes32 rights, address to, address contract_) external pure returns (bytes32) {
+        return RegistryHashes.erc20Hash(from, rights, to, contract_);
+    }
+
+    function erc1155Hash(address from, bytes32 rights, address to, uint256 tokenId, address contract_) external pure returns (bytes32) {
+        return RegistryHashes.erc1155Hash(from, rights, to, tokenId, contract_);
+    }
+
+    function allLocation(address from, bytes32 rights, address to) external pure returns (bytes32) {
+        return RegistryHashes.allLocation(from, rights, to);
+    }
+
+    function contractLocation(address from, bytes32 rights, address to, address contract_) external pure returns (bytes32) {
+        return RegistryHashes.contractLocation(from, rights, to, contract_);
+    }
+
+    function erc721Location(address from, bytes32 rights, address to, uint256 tokenId, address contract_) external pure returns (bytes32) {
+        return RegistryHashes.erc721Location(from, rights, to, tokenId, contract_);
+    }
+
+    function erc20Location(address from, bytes32 rights, address to, address contract_) external pure returns (bytes32) {
+        return RegistryHashes.erc20Location(from, rights, to, contract_);
+    }
+
+    function erc1155Location(address from, bytes32 rights, address to, uint256 tokenId, address contract_) external pure returns (bytes32) {
+        return RegistryHashes.erc1155Location(from, rights, to, tokenId, contract_);
+    }
+}

--- a/src/tools/RegistryHarness.sol
+++ b/src/tools/RegistryHarness.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.8.20;
 
 import {DelegateRegistry} from "src/DelegateRegistry.sol";
 
-import {RegistryHashes} from "../libraries/RegistryHashes.sol";
-
 /// @dev harness contract that exposes internal registry methods as external ones
 contract RegistryHarness is DelegateRegistry {
     constructor() {
@@ -31,26 +29,6 @@ contract RegistryHarness is DelegateRegistry {
 
     function exposedDelegationRevoked() external pure returns (address) {
         return DELEGATION_REVOKED;
-    }
-
-    function exposedComputeHashForAll(address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return RegistryHashes._computeAll(delegate, rights, vault);
-    }
-
-    function exposedComputeHashForContract(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return RegistryHashes._computeContract(contract_, delegate, rights, vault);
-    }
-
-    function exposedComputeHashForERC721(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault) external pure returns (bytes32) {
-        return RegistryHashes._computeERC721(contract_, delegate, rights, tokenId, vault);
-    }
-
-    function exposedComputeHashForERC20(address contract_, address delegate, bytes32 rights, address vault) external pure returns (bytes32) {
-        return RegistryHashes._computeERC20(contract_, delegate, rights, vault);
-    }
-
-    function exposedComputeHashForERC1155(address contract_, address delegate, bytes32 rights, uint256 tokenId, address vault) external pure returns (bytes32) {
-        return RegistryHashes._computeERC1155(contract_, delegate, rights, tokenId, vault);
     }
 
     function exposedPushDelegationHashes(address from, address to, bytes32 delegationHash) external {
@@ -105,19 +83,5 @@ contract RegistryHarness is DelegateRegistry {
 
     function exposedValidateDelegation(bytes32 location, address from) external view returns (bool) {
         return _validateDelegation(location, from);
-    }
-
-    // Relics moved to library
-
-    function exposedEncodeLastByteWithType(bytes32 input, DelegationType type_) external pure returns (bytes32) {
-        return RegistryHashes._encodeLastByteWithType(input, type_);
-    }
-
-    function exposedDecodeLastByteToType(bytes32 input) external pure returns (DelegationType) {
-        return RegistryHashes._decodeLastByteToType(input);
-    }
-
-    function exposedComputeLocation(bytes32 hash) external pure returns (bytes32 location) {
-        return RegistryHashes._computeLocation(hash);
     }
 }

--- a/test/HashBenchmark.t.sol
+++ b/test/HashBenchmark.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {HashHarness} from "src/tools/HashHarness.sol";
+import {IDelegateRegistry} from "src/IDelegateRegistry.sol";
+
+contract HashBenchmark is Test {
+    HashHarness hashHarness = new HashHarness();
+
+    function testHashGas(address from, bytes32 rights, address to, uint256 tokenId, address contract_, bytes32 hash) public view {
+        hashHarness.allHash(from, rights, to);
+        hashHarness.allLocation(from, rights, to);
+        hashHarness.contractHash(from, rights, to, contract_);
+        hashHarness.contractLocation(from, rights, to, contract_);
+        hashHarness.erc721Hash(from, rights, to, tokenId, contract_);
+        hashHarness.erc721Location(from, rights, to, tokenId, contract_);
+        hashHarness.erc20Hash(from, rights, to, contract_);
+        hashHarness.erc20Location(from, rights, to, contract_);
+        hashHarness.erc1155Hash(from, rights, to, tokenId, contract_);
+        hashHarness.erc1155Location(from, rights, to, tokenId, contract_);
+        hashHarness.location(hash);
+        hashHarness.decodeType(0);
+        hashHarness.encodeType(hash, uint256(IDelegateRegistry.DelegationType.ALL));
+    }
+}

--- a/test/RegistryHashTests.t.sol
+++ b/test/RegistryHashTests.t.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+import {IDelegateRegistry as IRegistry} from "src/IDelegateRegistry.sol";
+import {RegistryHashes as Hashes} from "src/libraries/RegistryHashes.sol";
+
+contract RegistryHashTests is Test {
+    /// @dev used to cross check internal constant in registry hashes with intended values
+    function testRegistryHashConstant() public {
+        assertEq(Hashes.deleteLastByte, bytes32(type(uint256).max << 8));
+        assertEq(Hashes.cleanAddress, bytes32(uint256(type(uint160).max)));
+        assertEq(Hashes.extractLastByte, type(uint8).max);
+        assertEq(Hashes.allType, uint256(IRegistry.DelegationType.ALL));
+        assertEq(Hashes.contractType, uint256(IRegistry.DelegationType.CONTRACT));
+        assertEq(Hashes.erc721Type, uint256(IRegistry.DelegationType.ERC721));
+        assertEq(Hashes.erc20Type, uint256(IRegistry.DelegationType.ERC20));
+        assertEq(Hashes.erc1155Type, uint256(IRegistry.DelegationType.ERC1155));
+        assertEq(Hashes.delegationSlot, 0);
+    }
+
+    /// @dev used to generate random delegation type within enum range
+    function _selectRandomType(uint256 seed) internal pure returns (IRegistry.DelegationType) {
+        if (seed % 6 == 0) return IRegistry.DelegationType.NONE;
+        if (seed % 6 == 1) return IRegistry.DelegationType.ALL;
+        if (seed % 6 == 2) return IRegistry.DelegationType.CONTRACT;
+        if (seed % 6 == 3) return IRegistry.DelegationType.ERC721;
+        if (seed % 6 == 4) return IRegistry.DelegationType.ERC20;
+        else return IRegistry.DelegationType.ERC1155;
+    }
+
+    /// @dev tests methods against previously used solidity methods
+    function testRegistryHashes(bytes32 _input, uint256 seed, address from, bytes32 rights, address to, address contract_, uint256 tokenId) public {
+        IRegistry.DelegationType _type = _selectRandomType(seed);
+        assertEq(Hashes.encodeType(_input, uint256(_type)), _encodeLastByteWithType(_input, _type));
+        bytes32 decodeTest = _encodeLastByteWithType(_input, _type);
+        assertEq(uint256(Hashes.decodeType(decodeTest)), uint256(_decodeLastByteToType(decodeTest)));
+        assertEq(Hashes.location(_input), _computeLocation(_input));
+        assertEq(Hashes.allHash(from, rights, to), _computeAll(from, rights, to));
+        assertEq(Hashes.allLocation(from, rights, to), _computeLocation(_computeAll(from, rights, to)));
+        assertEq(Hashes.contractHash(from, rights, to, contract_), _computeContract(from, rights, to, contract_));
+        assertEq(Hashes.contractLocation(from, rights, to, contract_), _computeLocation(_computeContract(from, rights, to, contract_)));
+        assertEq(Hashes.erc721Hash(from, rights, to, tokenId, contract_), _computeERC721(from, rights, to, tokenId, contract_));
+        assertEq(Hashes.erc721Location(from, rights, to, tokenId, contract_), _computeLocation(_computeERC721(from, rights, to, tokenId, contract_)));
+        assertEq(Hashes.erc20Hash(from, rights, to, contract_), _computeERC20(from, rights, to, contract_));
+        assertEq(Hashes.erc20Location(from, rights, to, contract_), _computeLocation(_computeERC20(from, rights, to, contract_)));
+        assertEq(Hashes.erc1155Hash(from, rights, to, tokenId, contract_), _computeERC1155(from, rights, to, tokenId, contract_));
+        assertEq(Hashes.erc1155Location(from, rights, to, tokenId, contract_), _computeLocation(_computeERC1155(from, rights, to, tokenId, contract_)));
+    }
+
+    /// @dev used to cross check that location by type method gives the same result as location(hash for type) method
+    function testRegistryHashesLocationEquivalence(address from, bytes32 rights, address to, uint256 tokenId, address contract_) public {
+        assertEq(Hashes.allLocation(from, rights, to), Hashes.location(Hashes.allHash(from, rights, to)));
+        assertEq(Hashes.contractLocation(from, rights, to, contract_), Hashes.location(Hashes.contractHash(from, rights, to, contract_)));
+        assertEq(Hashes.erc721Location(from, rights, to, tokenId, contract_), Hashes.location(Hashes.erc721Hash(from, rights, to, tokenId, contract_)));
+        assertEq(Hashes.erc20Location(from, rights, to, contract_), Hashes.location(Hashes.erc20Hash(from, rights, to, contract_)));
+        assertEq(Hashes.erc1155Location(from, rights, to, tokenId, contract_), Hashes.location(Hashes.erc1155Hash(from, rights, to, tokenId, contract_)));
+    }
+
+    /// @dev tests for collisions between the types, additionally searches for collisions by holding from != notFrom constant and fuzzes variations of the other
+    /// parameters
+    function testRegistryHashesForTypeCollisions(
+        address from,
+        bytes32 rights,
+        address to,
+        uint256 tokenId,
+        address contract_,
+        address notFrom,
+        bytes32 searchRights,
+        address searchTo,
+        uint256 searchTokenId,
+        address searchContract_
+    ) public {
+        vm.assume(from != notFrom);
+        bytes32[] memory uniqueHashes = new bytes32[](10);
+        uniqueHashes[0] = Hashes.allHash(from, rights, to);
+        uniqueHashes[1] = Hashes.allHash(notFrom, searchRights, searchTo);
+        uniqueHashes[2] = Hashes.contractHash(from, rights, to, contract_);
+        uniqueHashes[3] = Hashes.contractHash(notFrom, searchRights, searchTo, searchContract_);
+        uniqueHashes[4] = Hashes.erc721Hash(from, rights, to, tokenId, contract_);
+        uniqueHashes[5] = Hashes.erc721Hash(notFrom, searchRights, searchTo, searchTokenId, searchContract_);
+        uniqueHashes[6] = Hashes.erc20Hash(from, rights, to, contract_);
+        uniqueHashes[7] = Hashes.erc20Hash(notFrom, searchRights, searchTo, searchContract_);
+        uniqueHashes[8] = Hashes.erc1155Hash(from, rights, to, tokenId, contract_);
+        uniqueHashes[9] = Hashes.erc1155Hash(notFrom, searchRights, searchTo, searchTokenId, searchContract_);
+        for (uint256 i = 0; i < uniqueHashes.length; i++) {
+            for (uint256 j = 0; j < uniqueHashes.length; j++) {
+                if (j != i) assertTrue(uniqueHashes[i] != uniqueHashes[j]);
+                else assertEq(uniqueHashes[i], uniqueHashes[j]);
+            }
+        }
+    }
+
+    /// @dev internal functions of the original registry hash specification to test optimized methods work as intended
+    function _computeAll(address from, bytes32 rights, address to) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(from, rights, to)), IRegistry.DelegationType.ALL);
+    }
+
+    function _computeContract(address from, bytes32 rights, address to, address contract_) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(from, rights, to, contract_)), IRegistry.DelegationType.CONTRACT);
+    }
+
+    function _computeERC721(address from, bytes32 rights, address to, uint256 tokenId, address contract_) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(from, rights, to, tokenId, contract_)), IRegistry.DelegationType.ERC721);
+    }
+
+    function _computeERC20(address from, bytes32 rights, address to, address contract_) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(from, rights, to, contract_)), IRegistry.DelegationType.ERC20);
+    }
+
+    function _computeERC1155(address from, bytes32 rights, address to, uint256 tokenId, address contract_) internal pure returns (bytes32) {
+        return _encodeLastByteWithType(keccak256(abi.encode(from, rights, to, tokenId, contract_)), IRegistry.DelegationType.ERC1155);
+    }
+
+    function _encodeLastByteWithType(bytes32 _input, IRegistry.DelegationType _type) internal pure returns (bytes32) {
+        return (_input & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00) | bytes32(uint256(_type));
+    }
+
+    function _decodeLastByteToType(bytes32 _input) internal pure returns (IRegistry.DelegationType) {
+        return IRegistry.DelegationType(uint8(uint256(_input) & 0xFF));
+    }
+
+    function _computeLocation(bytes32 hash) internal pure returns (bytes32 location) {
+        location = keccak256(abi.encode(hash, 0)); // delegations mapping is at slot 0
+    }
+}

--- a/test/RegistrySingularIntegrations.t.sol
+++ b/test/RegistrySingularIntegrations.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import {Test} from "forge-std/Test.sol";
 import {DelegateRegistry as Registry} from "src/DelegateRegistry.sol";
+import {RegistryHashes as Hashes} from "src/libraries/RegistryHashes.sol";
 import {IDelegateRegistry as IRegistry} from "src/IDelegateRegistry.sol";
 import {RegistryHarness as Harness} from "src/tools/RegistryHarness.sol";
 
@@ -152,19 +153,20 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadAll() internal {
+        bytes32 checkHash = Hashes.allHash(_vault, _rights, _delegate);
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForAll(_delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], checkHash);
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForAll(_delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], checkHash);
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposedComputeHashForAll(_delegate, _rights, _vault);
+        hashes[0] = checkHash;
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -263,19 +265,20 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadContract() internal {
+        bytes32 checkHash = Hashes.contractHash(_vault, _rights, _delegate, _contract);
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForContract(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], checkHash);
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForContract(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], checkHash);
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposedComputeHashForContract(_contract, _delegate, _rights, _vault);
+        hashes[0] = checkHash;
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -363,19 +366,20 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadERC721() internal {
+        bytes32 checkHash = Hashes.erc721Hash(_vault, _rights, _delegate, _tokenId, _contract);
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], checkHash);
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], checkHash);
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposedComputeHashForERC721(_contract, _delegate, _rights, _tokenId, _vault);
+        hashes[0] = checkHash;
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -465,19 +469,20 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadERC20() internal {
+        bytes32 checkHash = Hashes.erc20Hash(_vault, _rights, _delegate, _contract);
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForERC20(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], checkHash);
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForERC20(_contract, _delegate, _rights, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], checkHash);
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposedComputeHashForERC20(_contract, _delegate, _rights, _vault);
+        hashes[0] = checkHash;
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }
@@ -569,19 +574,20 @@ contract DelegateSingularIntegrations is Test {
     }
 
     function _checkReadERC1155() internal {
+        bytes32 checkHash = Hashes.erc1155Hash(_vault, _rights, _delegate, _tokenId, _contract);
         // Check outcomes of getIncomingDelegationHashes
         assertEq(registry.getIncomingDelegationHashes(_delegate).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], harness.exposedComputeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault));
+            assertEq(registry.getIncomingDelegationHashes(_delegate)[0], checkHash);
         }
         // Check outcomes of getOutgoingDelegationHashes
         assertEq(registry.getOutgoingDelegationHashes(_vault).length == 1, _enable);
         if (_enable) {
-            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], harness.exposedComputeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault));
+            assertEq(registry.getOutgoingDelegationHashes(_vault)[0], checkHash);
         }
         // Check outcomes of getDelegationsFromHashes
         bytes32[] memory hashes = new bytes32[](1);
-        hashes[0] = harness.exposedComputeHashForERC1155(_contract, _delegate, _rights, _tokenId, _vault);
+        hashes[0] = checkHash;
         assertEq(registry.getDelegationsFromHashes(hashes).length, 1);
         _checkDelegation(registry.getDelegationsFromHashes(hashes)[0]);
     }


### PR DESCRIPTION
### Major changes to `RegistryHashes` library ###

Created custom hash and location calculation methods for each delegation type. Gas reductions all round. Most notable are the 10-17% reductions in the check methods. Main downside is the ~15% increased deployment cost, although this wasn't very high to start with. Method name changes to reduce visual complexity of code.

### `HashHarness` for `RegistryHashes` library ###

Allows easy benchmarking of the hash library.

### Removed unused code from `RegistryHarness` ###

These were relics from the hash methods being in `DelegateRegistry.sol`.

### Unit tests for registry hashes ###

Moved pre-change registry hash methods to tests where they are used to validate the function of the updated methods. Added tests to check / search for collisions between the different types of delegation hash. Added tests to validate that the constants used in `RegistryHashes` are correct.

### Minor changes ###

- Slither tests now fails on Low impact issues and above.
- Removed doubled shifts in storage read / writes in registry.