### PR TITLE
Storage method library, reduced visual complexity

### DIFF
--- a/slitherReport.md
+++ b/slitherReport.md
@@ -14,52 +14,52 @@ src/DelegateRegistry.sol#L255-L261
 
 
  - [ ] ID-1
-[DelegateRegistry._loadDelegationBytes32(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L357-L361) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L358-L360)
+[DelegateRegistry._writeDelegation(bytes32,RegistryStorage.Positions,bytes32)](src/DelegateRegistry.sol#L285-L289) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L286-L288)
 
-src/DelegateRegistry.sol#L357-L361
+src/DelegateRegistry.sol#L285-L289
 
 
  - [ ] ID-2
-[DelegateRegistry._loadDelegationUint(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L364-L368) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L365-L367)
+[DelegateRegistry._loadDelegationAddresses(bytes32,RegistryStorage.Positions,RegistryStorage.Positions)](src/DelegateRegistry.sol#L387-L399) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L394-L397)
 
-src/DelegateRegistry.sol#L364-L368
+src/DelegateRegistry.sol#L387-L399
 
 
  - [ ] ID-3
-[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,uint256)](src/DelegateRegistry.sol#L292-L296) uses assembly
+[DelegateRegistry._writeDelegation(bytes32,RegistryStorage.Positions,uint256)](src/DelegateRegistry.sol#L292-L296) uses assembly
 	- [INLINE ASM](src/DelegateRegistry.sol#L293-L295)
 
 src/DelegateRegistry.sol#L292-L296
 
 
  - [ ] ID-4
-[DelegateRegistry._writeDelegation(bytes32,IDelegateRegistry.StoragePositions,bytes32)](src/DelegateRegistry.sol#L285-L289) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L286-L288)
-
-src/DelegateRegistry.sol#L285-L289
-
-
- - [ ] ID-5
-[DelegateRegistry._writeDelegationAddresses(bytes32,IDelegateRegistry.StoragePositions,IDelegateRegistry.StoragePositions,address,address,address)](src/DelegateRegistry.sol#L299-L306) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L302-L305)
-
-src/DelegateRegistry.sol#L299-L306
-
-
- - [ ] ID-6
-[DelegateRegistry._loadFrom(bytes32,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L371-L375) uses assembly
+[DelegateRegistry._loadDelegationUint(bytes32,RegistryStorage.Positions)](src/DelegateRegistry.sol#L371-L375) uses assembly
 	- [INLINE ASM](src/DelegateRegistry.sol#L372-L374)
 
 src/DelegateRegistry.sol#L371-L375
 
 
- - [ ] ID-7
-[DelegateRegistry._loadDelegationAddresses(bytes32,IDelegateRegistry.StoragePositions,IDelegateRegistry.StoragePositions)](src/DelegateRegistry.sol#L378-L391) uses assembly
-	- [INLINE ASM](src/DelegateRegistry.sol#L383-L390)
+ - [ ] ID-5
+[DelegateRegistry._loadFrom(bytes32,RegistryStorage.Positions)](src/DelegateRegistry.sol#L378-L384) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L380-L382)
 
-src/DelegateRegistry.sol#L378-L391
+src/DelegateRegistry.sol#L378-L384
+
+
+ - [ ] ID-6
+[DelegateRegistry._loadDelegationBytes32(bytes32,RegistryStorage.Positions)](src/DelegateRegistry.sol#L364-L368) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L365-L367)
+
+src/DelegateRegistry.sol#L364-L368
+
+
+ - [ ] ID-7
+[DelegateRegistry._writeDelegationAddresses(bytes32,RegistryStorage.Positions,RegistryStorage.Positions,address,address,address)](src/DelegateRegistry.sol#L299-L312) uses assembly
+	- [INLINE ASM](src/DelegateRegistry.sol#L308-L311)
+
+src/DelegateRegistry.sol#L299-L312
 
 
  - [ ] ID-8

--- a/src/DelegateRegistry.sol
+++ b/src/DelegateRegistry.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.20;
 
-import {IDelegateRegistry} from "./IDelegateRegistry.sol";
-
-import {RegistryHashes} from "./libraries/RegistryHashes.sol";
+import {IDelegateRegistry as IDelegateRegistry} from "./IDelegateRegistry.sol";
+import {RegistryHashes as Hashes} from "./libraries/RegistryHashes.sol";
+import {RegistryStorage as Storage} from "./libraries/RegistryStorage.sol";
 
 /**
  * @title DelegateRegistry
@@ -45,64 +45,64 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function delegateAll(address to, bytes32 rights, bool enable) external override returns (bytes32 hash) {
-        hash = RegistryHashes.allHash(msg.sender, rights, to);
-        bytes32 location = RegistryHashes.location(hash);
-        if (_loadFrom(location, StoragePositions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        hash = Hashes.allHash(msg.sender, rights, to);
+        bytes32 location = Hashes.location(hash);
+        if (_loadFrom(location, Storage.Positions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, msg.sender, to, address(0));
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, msg.sender, to, address(0));
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, rights);
         } else {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, "");
         }
         emit DelegateAll(msg.sender, to, rights, enable);
     }
 
     /// @inheritdoc IDelegateRegistry
     function delegateContract(address to, address contract_, bytes32 rights, bool enable) external override returns (bytes32 hash) {
-        hash = RegistryHashes.contractHash(msg.sender, rights, to, contract_);
-        bytes32 location = RegistryHashes.location(hash);
-        if (_loadFrom(location, StoragePositions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        hash = Hashes.contractHash(msg.sender, rights, to, contract_);
+        bytes32 location = Hashes.location(hash);
+        if (_loadFrom(location, Storage.Positions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, msg.sender, to, contract_);
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, msg.sender, to, contract_);
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, rights);
         } else {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, "");
         }
         emit DelegateContract(msg.sender, to, contract_, rights, enable);
     }
 
     /// @inheritdoc IDelegateRegistry
     function delegateERC721(address to, address contract_, uint256 tokenId, bytes32 rights, bool enable) external override returns (bytes32 hash) {
-        hash = RegistryHashes.erc721Hash(msg.sender, rights, to, tokenId, contract_);
-        bytes32 location = RegistryHashes.location(hash);
-        if (_loadFrom(location, StoragePositions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        hash = Hashes.erc721Hash(msg.sender, rights, to, tokenId, contract_);
+        bytes32 location = Hashes.location(hash);
+        if (_loadFrom(location, Storage.Positions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, msg.sender, to, contract_);
-            _writeDelegation(location, StoragePositions.tokenId, tokenId);
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, msg.sender, to, contract_);
+            _writeDelegation(location, Storage.Positions.tokenId, tokenId);
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, rights);
         } else {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
-            _writeDelegation(location, StoragePositions.tokenId, "");
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
+            _writeDelegation(location, Storage.Positions.tokenId, "");
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, "");
         }
         emit DelegateERC721(msg.sender, to, contract_, tokenId, rights, enable);
     }
 
     // @inheritdoc IDelegateRegistry
     function delegateERC20(address to, address contract_, uint256 amount, bytes32 rights, bool enable) external override returns (bytes32 hash) {
-        hash = RegistryHashes.erc20Hash(msg.sender, rights, to, contract_);
-        bytes32 location = RegistryHashes.location(hash);
-        if (_loadFrom(location, StoragePositions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        hash = Hashes.erc20Hash(msg.sender, rights, to, contract_);
+        bytes32 location = Hashes.location(hash);
+        if (_loadFrom(location, Storage.Positions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, msg.sender, to, contract_);
-            _writeDelegation(location, StoragePositions.amount, amount);
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, msg.sender, to, contract_);
+            _writeDelegation(location, Storage.Positions.amount, amount);
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, rights);
         } else {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
-            _writeDelegation(location, StoragePositions.amount, "");
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
+            _writeDelegation(location, Storage.Positions.amount, "");
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, "");
         }
         emit DelegateERC20(msg.sender, to, contract_, amount, rights, enable);
     }
@@ -112,19 +112,19 @@ contract DelegateRegistry is IDelegateRegistry {
      * @dev The actual amount is not encoded in the hash, just the existence of a amount (since it is an upper bound)
      */
     function delegateERC1155(address to, address contract_, uint256 tokenId, uint256 amount, bytes32 rights, bool enable) external override returns (bytes32 hash) {
-        hash = RegistryHashes.erc1155Hash(msg.sender, rights, to, tokenId, contract_);
-        bytes32 location = RegistryHashes.location(hash);
-        if (_loadFrom(location, StoragePositions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
+        hash = Hashes.erc1155Hash(msg.sender, rights, to, tokenId, contract_);
+        bytes32 location = Hashes.location(hash);
+        if (_loadFrom(location, Storage.Positions.firstPacked) == DELEGATION_EMPTY) _pushDelegationHashes(msg.sender, to, hash);
         if (enable) {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, msg.sender, to, contract_);
-            _writeDelegation(location, StoragePositions.amount, amount);
-            _writeDelegation(location, StoragePositions.tokenId, tokenId);
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, rights);
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, msg.sender, to, contract_);
+            _writeDelegation(location, Storage.Positions.amount, amount);
+            _writeDelegation(location, Storage.Positions.tokenId, tokenId);
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, rights);
         } else {
-            _writeDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
-            _writeDelegation(location, StoragePositions.amount, "");
-            _writeDelegation(location, StoragePositions.tokenId, "");
-            if (rights != "") _writeDelegation(location, StoragePositions.rights, "");
+            _writeDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, DELEGATION_REVOKED, address(0), address(0));
+            _writeDelegation(location, Storage.Positions.amount, "");
+            _writeDelegation(location, Storage.Positions.tokenId, "");
+            if (rights != "") _writeDelegation(location, Storage.Positions.rights, "");
         }
         emit DelegateERC1155(msg.sender, to, contract_, tokenId, amount, rights, enable);
     }
@@ -135,58 +135,54 @@ contract DelegateRegistry is IDelegateRegistry {
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForAll(address to, address from, bytes32 rights) external view override returns (bool valid) {
-        valid = _validateDelegation(RegistryHashes.allLocation(from, "", to), from);
-        if (rights != "" && !valid) valid = _validateDelegation(RegistryHashes.allLocation(from, rights, to), from);
+        valid = _validateDelegation(Hashes.allLocation(from, "", to), from);
+        if (rights != "" && !valid) valid = _validateDelegation(Hashes.allLocation(from, rights, to), from);
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForContract(address to, address from, address contract_, bytes32 rights) external view override returns (bool valid) {
-        valid = _validateDelegation(RegistryHashes.allLocation(from, "", to), from) || _validateDelegation(RegistryHashes.contractLocation(from, "", to, contract_), from);
+        valid = _validateDelegation(Hashes.allLocation(from, "", to), from) || _validateDelegation(Hashes.contractLocation(from, "", to, contract_), from);
         if (rights != "" && !valid) {
-            valid = _validateDelegation(RegistryHashes.allLocation(from, rights, to), from)
-                || _validateDelegation(RegistryHashes.contractLocation(from, rights, to, contract_), from);
+            valid = _validateDelegation(Hashes.allLocation(from, rights, to), from) || _validateDelegation(Hashes.contractLocation(from, rights, to, contract_), from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForERC721(address to, address from, address contract_, uint256 tokenId, bytes32 rights) external view override returns (bool valid) {
-        valid = _validateDelegation(RegistryHashes.allLocation(from, "", to), from) || _validateDelegation(RegistryHashes.contractLocation(from, "", to, contract_), from)
-            || _validateDelegation(RegistryHashes.erc721Location(from, "", to, tokenId, contract_), from);
+        valid = _validateDelegation(Hashes.allLocation(from, "", to), from) || _validateDelegation(Hashes.contractLocation(from, "", to, contract_), from)
+            || _validateDelegation(Hashes.erc721Location(from, "", to, tokenId, contract_), from);
         if (rights != "" && !valid) {
-            valid = _validateDelegation(RegistryHashes.allLocation(from, rights, to), from)
-                || _validateDelegation(RegistryHashes.contractLocation(from, rights, to, contract_), from)
-                || _validateDelegation(RegistryHashes.erc721Location(from, rights, to, tokenId, contract_), from);
+            valid = _validateDelegation(Hashes.allLocation(from, rights, to), from) || _validateDelegation(Hashes.contractLocation(from, rights, to, contract_), from)
+                || _validateDelegation(Hashes.erc721Location(from, rights, to, tokenId, contract_), from);
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForERC20(address to, address from, address contract_, bytes32 rights) external view override returns (uint256 amount) {
-        bytes32 location = RegistryHashes.erc20Location(from, "", to, contract_);
-        amount = (
-            _validateDelegation(RegistryHashes.allLocation(from, "", to), from) || _validateDelegation(RegistryHashes.contractLocation(from, "", to, contract_), from)
-        ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
+        bytes32 location = Hashes.erc20Location(from, "", to, contract_);
+        amount = (_validateDelegation(Hashes.allLocation(from, "", to), from) || _validateDelegation(Hashes.contractLocation(from, "", to, contract_), from))
+            ? type(uint256).max
+            : (_validateDelegation(location, from) ? _loadDelegationUint(location, Storage.Positions.amount) : 0);
         if (rights != "" && amount != type(uint256).max) {
-            location = RegistryHashes.erc20Location(from, rights, to, contract_);
+            location = Hashes.erc20Location(from, rights, to, contract_);
             uint256 rightsBalance = (
-                _validateDelegation(RegistryHashes.allLocation(from, rights, to), from)
-                    || _validateDelegation(RegistryHashes.contractLocation(from, rights, to, contract_), from)
-            ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
+                _validateDelegation(Hashes.allLocation(from, rights, to), from) || _validateDelegation(Hashes.contractLocation(from, rights, to, contract_), from)
+            ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, Storage.Positions.amount) : 0);
             amount = rightsBalance > amount ? rightsBalance : amount;
         }
     }
 
     /// @inheritdoc IDelegateRegistry
     function checkDelegateForERC1155(address to, address from, address contract_, uint256 tokenId, bytes32 rights) external view override returns (uint256 amount) {
-        bytes32 location = RegistryHashes.erc1155Location(from, "", to, tokenId, contract_);
-        amount = (
-            _validateDelegation(RegistryHashes.allLocation(from, "", to), from) || _validateDelegation(RegistryHashes.contractLocation(from, "", to, contract_), from)
-        ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
+        bytes32 location = Hashes.erc1155Location(from, "", to, tokenId, contract_);
+        amount = (_validateDelegation(Hashes.allLocation(from, "", to), from) || _validateDelegation(Hashes.contractLocation(from, "", to, contract_), from))
+            ? type(uint256).max
+            : (_validateDelegation(location, from) ? _loadDelegationUint(location, Storage.Positions.amount) : 0);
         if (rights != "" && amount != type(uint256).max) {
-            location = RegistryHashes.erc1155Location(from, rights, to, tokenId, contract_);
+            location = Hashes.erc1155Location(from, rights, to, tokenId, contract_);
             uint256 rightsBalance = (
-                _validateDelegation(RegistryHashes.allLocation(from, rights, to), from)
-                    || _validateDelegation(RegistryHashes.contractLocation(from, rights, to, contract_), from)
-            ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, StoragePositions.amount) : 0);
+                _validateDelegation(Hashes.allLocation(from, rights, to), from) || _validateDelegation(Hashes.contractLocation(from, rights, to, contract_), from)
+            ) ? type(uint256).max : (_validateDelegation(location, from) ? _loadDelegationUint(location, Storage.Positions.amount) : 0);
             amount = rightsBalance > amount ? rightsBalance : amount;
         }
     }
@@ -220,20 +216,20 @@ contract DelegateRegistry is IDelegateRegistry {
         delegations_ = new Delegation[](hashes.length);
         unchecked {
             for (uint256 i = 0; i < hashes.length; ++i) {
-                bytes32 location = RegistryHashes.location(hashes[i]);
-                address from = _loadFrom(location, StoragePositions.firstPacked);
+                bytes32 location = Hashes.location(hashes[i]);
+                address from = _loadFrom(location, Storage.Positions.firstPacked);
                 if (from == DELEGATION_EMPTY || from == DELEGATION_REVOKED) {
                     delegations_[i] = Delegation({type_: DelegationType.NONE, to: address(0), from: address(0), rights: "", amount: 0, contract_: address(0), tokenId: 0});
                 } else {
-                    (, address to, address contract_) = _loadDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked);
+                    (, address to, address contract_) = _loadDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked);
                     delegations_[i] = Delegation({
-                        type_: RegistryHashes.decodeType(hashes[i]),
+                        type_: Hashes.decodeType(hashes[i]),
                         to: to,
                         from: from,
-                        rights: _loadDelegationBytes32(location, StoragePositions.rights),
-                        amount: _loadDelegationUint(location, StoragePositions.amount),
+                        rights: _loadDelegationBytes32(location, Storage.Positions.rights),
+                        amount: _loadDelegationUint(location, Storage.Positions.amount),
                         contract_: contract_,
-                        tokenId: _loadDelegationUint(location, StoragePositions.tokenId)
+                        tokenId: _loadDelegationUint(location, Storage.Positions.tokenId)
                     });
                 }
             }
@@ -282,26 +278,27 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @dev Helper function that writes bytes32 data to delegation data location at array position
-    function _writeDelegation(bytes32 location, StoragePositions position, bytes32 data) internal {
+    function _writeDelegation(bytes32 location, Storage.Positions position, bytes32 data) internal {
         assembly {
             sstore(add(location, position), data)
         }
     }
 
     /// @dev Helper function that writes uint256 data to delegation data location at array position
-    function _writeDelegation(bytes32 location, StoragePositions position, uint256 data) internal {
+    function _writeDelegation(bytes32 location, Storage.Positions position, uint256 data) internal {
         assembly {
             sstore(add(location, position), data)
         }
     }
 
     /// @dev Helper function that writes addresses according to the packing rule for delegation storage
-    function _writeDelegationAddresses(bytes32 location, StoragePositions firstPacked, StoragePositions secondPacked, address from, address to, address contract_)
+    function _writeDelegationAddresses(bytes32 location, Storage.Positions firstPacked, Storage.Positions secondPacked, address from, address to, address contract_)
         internal
     {
+        (bytes32 firstSlot, bytes32 secondSlot) = Storage.packAddresses(from, to, contract_);
         assembly {
-            sstore(add(location, firstPacked), or(shl(160, shr(192, shl(96, contract_))), shr(96, shl(96, from))))
-            sstore(add(location, secondPacked), or(shl(160, shr(96, shl(96, contract_))), shr(96, shl(96, to))))
+            sstore(add(location, firstPacked), firstSlot)
+            sstore(add(location, secondPacked), secondSlot)
         }
     }
 
@@ -314,22 +311,22 @@ contract DelegateRegistry is IDelegateRegistry {
         unchecked {
             for (uint256 i = 0; i < hashesLength; ++i) {
                 hash = hashes[i];
-                if (_loadFrom(RegistryHashes.location(hash), StoragePositions.firstPacked) > DELEGATION_REVOKED) filteredHashes[count++] = hash;
+                if (_loadFrom(Hashes.location(hash), Storage.Positions.firstPacked) > DELEGATION_REVOKED) filteredHashes[count++] = hash;
             }
             delegations_ = new Delegation[](count);
             bytes32 location;
             for (uint256 i = 0; i < count; ++i) {
                 hash = filteredHashes[i];
-                location = RegistryHashes.location(hash);
-                (address from, address to, address contract_) = _loadDelegationAddresses(location, StoragePositions.firstPacked, StoragePositions.secondPacked);
+                location = Hashes.location(hash);
+                (address from, address to, address contract_) = _loadDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked);
                 delegations_[i] = Delegation({
-                    type_: RegistryHashes.decodeType(hash),
+                    type_: Hashes.decodeType(hash),
                     to: to,
                     from: from,
-                    rights: _loadDelegationBytes32(location, StoragePositions.rights),
-                    amount: _loadDelegationUint(location, StoragePositions.amount),
+                    rights: _loadDelegationBytes32(location, Storage.Positions.rights),
+                    amount: _loadDelegationUint(location, Storage.Positions.amount),
                     contract_: contract_,
-                    tokenId: _loadDelegationUint(location, StoragePositions.tokenId)
+                    tokenId: _loadDelegationUint(location, Storage.Positions.tokenId)
                 });
             }
         }
@@ -344,7 +341,7 @@ contract DelegateRegistry is IDelegateRegistry {
         unchecked {
             for (uint256 i = 0; i < hashesLength; ++i) {
                 hash = hashes[i];
-                if (_loadFrom(RegistryHashes.location(hash), StoragePositions.firstPacked) > DELEGATION_REVOKED) filteredHashes[count++] = hash;
+                if (_loadFrom(Hashes.location(hash), Storage.Positions.firstPacked) > DELEGATION_REVOKED) filteredHashes[count++] = hash;
             }
             validHashes = new bytes32[](count);
             for (uint256 i = 0; i < count; ++i) {
@@ -354,44 +351,45 @@ contract DelegateRegistry is IDelegateRegistry {
     }
 
     /// @dev Helper function that loads delegation data from a particular array position and returns as bytes32
-    function _loadDelegationBytes32(bytes32 location, StoragePositions position) internal view returns (bytes32 data) {
+    function _loadDelegationBytes32(bytes32 location, Storage.Positions position) internal view returns (bytes32 data) {
         assembly {
             data := sload(add(location, position))
         }
     }
 
     /// @dev Helper function that loads delegation data from a particular array position and returns as uint256
-    function _loadDelegationUint(bytes32 location, StoragePositions position) internal view returns (uint256 data) {
+    function _loadDelegationUint(bytes32 location, Storage.Positions position) internal view returns (uint256 data) {
         assembly {
             data := sload(add(location, position))
         }
     }
 
     // @dev Helper function that loads the from address from storage according to the packing rule for delegation storage
-    function _loadFrom(bytes32 location, StoragePositions firstPacked) internal view returns (address from) {
+    function _loadFrom(bytes32 location, Storage.Positions firstPacked) internal view returns (address) {
+        bytes32 data;
         assembly {
-            from := shr(96, shl(96, sload(add(location, firstPacked))))
+            data := sload(add(location, firstPacked))
         }
+        return Storage.unpackAddress(data);
     }
 
     /// @dev Helper function that loads the address for the delegation according to the packing rule for delegation storage
-    function _loadDelegationAddresses(bytes32 location, StoragePositions firstPacked, StoragePositions secondPacked)
+    function _loadDelegationAddresses(bytes32 location, Storage.Positions firstPacked, Storage.Positions secondPacked)
         internal
         view
         returns (address from, address to, address contract_)
     {
+        bytes32 firstSlot;
+        bytes32 secondSlot;
         assembly {
-            let firstSlot := sload(add(location, firstPacked))
-            let secondSlot := sload(add(location, secondPacked))
-
-            from := shr(96, shl(96, firstSlot))
-            to := shr(96, shl(96, secondSlot))
-            contract_ := or(shl(96, shr(192, shl(32, firstSlot))), shr(160, secondSlot))
+            firstSlot := sload(add(location, firstPacked))
+            secondSlot := sload(add(location, secondPacked))
         }
+        (from, to, contract_) = Storage.unPackAddresses(firstSlot, secondSlot);
     }
 
     /// @dev Helper function to establish whether a delegation is enabled
     function _validateDelegation(bytes32 location, address from) internal view returns (bool) {
-        return (_loadFrom(location, StoragePositions.firstPacked) == from && from > DELEGATION_REVOKED);
+        return (_loadFrom(location, Storage.Positions.firstPacked) == from && from > DELEGATION_REVOKED);
     }
 }

--- a/src/IDelegateRegistry.sol
+++ b/src/IDelegateRegistry.sol
@@ -208,14 +208,6 @@ interface IDelegateRegistry {
     /**
      * ----------- STORAGE ACCESS -----------
      */
-    /// @dev Standardizes storage positions of delegation data
-    enum StoragePositions {
-        firstPacked, //     | 4 bytes empty | first 8 bytes of contract address | 20 bytes of from address |
-        secondPacked, //     | last 12 bytes of contract address | 20 bytes of to address |
-        rights,
-        tokenId,
-        amount
-    }
 
     /**
      * @notice allows external contract to read arbitrary storage slot

--- a/src/libraries/RegistryStorage.sol
+++ b/src/libraries/RegistryStorage.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+library RegistryStorage {
+    /// @dev Standardizes storage positions of delegation data
+    enum Positions {
+        firstPacked, //     | 4 bytes empty | first 8 bytes of contract address | 20 bytes of from address |
+        secondPacked, //    |        last 12 bytes of contract address          | 20 bytes of to address   |
+        rights,
+        tokenId,
+        amount
+    }
+
+    /// @dev Used to clean address types of dirty bits with and(address, cleanAddress)
+    bytes32 internal constant cleanAddress = 0x000000000000000000000000ffffffffffffffffffffffffffffffffffffffff;
+
+    /// @dev Used to clean everything but the first 8 bytes of an address
+    bytes32 internal constant cleanFirst8BytesAddress = 0x000000000000000000000000ffffffffffffffff000000000000000000000000;
+
+    /// @dev Used to clean everything but the last 12 bytes of an address
+    bytes32 internal constant cleanLast12BytesAddress = 0x0000000000000000000000000000000000000000ffffffffffffffffffffffff;
+
+    /// @dev Used to clean everything but the first 8 bytes of an address in the packed position
+    bytes32 internal constant cleanPacked8BytesAddress = 0x00000000ffffffffffffffff0000000000000000000000000000000000000000;
+
+    /**
+     * @notice Helper function that packs from, to, and contract_ address to into the two slot configuration
+     * @param from is the address making the delegation
+     * @param to is the address receiving the delegation
+     * @param contract_ is the contract address associated with the delegation (optional)
+     * @return firstPacked is the firstPacked storage configured with the parameters
+     * @return secondPacked is the secondPacked storage configured with the parameters
+     * @dev will not revert if from, to, and contract_ are > uint160, any inputs with dirty bits outside the last 20 bytes will be cleaned
+     */
+    function packAddresses(address from, address to, address contract_) internal pure returns (bytes32 firstPacked, bytes32 secondPacked) {
+        assembly {
+            firstPacked := or(shl(64, and(contract_, cleanFirst8BytesAddress)), and(from, cleanAddress))
+            secondPacked := or(shl(160, and(contract_, cleanLast12BytesAddress)), and(to, cleanAddress))
+        }
+    }
+
+    /**
+     * @notice Helper function that unpacks from, to, and contract_ address inside the firstPacked secondPacked storage configuration
+     * @param firstPacked is the firstPacked storage to be decoded
+     * @param secondPacked is the secondPacked storage to be decoded
+     * @return from is the address making the delegation
+     * @return to is the address receiving the delegation
+     * @return contract_ is the contract address associated with the delegation
+     * @dev will not revert if from, to, and contract_ are > uint160, any inputs with dirty bits outside the last 20 bytes will be cleaned
+     */
+    function unPackAddresses(bytes32 firstPacked, bytes32 secondPacked) internal pure returns (address from, address to, address contract_) {
+        assembly {
+            from := and(firstPacked, cleanAddress)
+            to := and(secondPacked, cleanAddress)
+            contract_ := or(shr(64, and(firstPacked, cleanPacked8BytesAddress)), shr(160, secondPacked))
+        }
+    }
+
+    /**
+     * @notice Helper function that can unpack the from or to address from their respective packed slots in the registry
+     * @param packedSlot is the slot containing the from or to address
+     * @return unpacked from or to address
+     * @dev will not work if you want to obtain the contract address, use unpackAddresses
+     */
+    function unpackAddress(bytes32 packedSlot) internal pure returns (address unpacked) {
+        assembly {
+            unpacked := and(packedSlot, cleanAddress)
+        }
+    }
+}

--- a/src/tools/RegistryHarness.sol
+++ b/src/tools/RegistryHarness.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.20;
 
 import {DelegateRegistry} from "src/DelegateRegistry.sol";
 
+import {RegistryStorage} from "src/libraries/RegistryStorage.sol";
+
 /// @dev harness contract that exposes internal registry methods as external ones
 contract RegistryHarness is DelegateRegistry {
     constructor() {
@@ -35,17 +37,22 @@ contract RegistryHarness is DelegateRegistry {
         _pushDelegationHashes(from, to, delegationHash);
     }
 
-    function exposedWriteDelegation(bytes32 location, StoragePositions position, bytes32 data) external {
+    function exposedWriteDelegation(bytes32 location, RegistryStorage.Positions position, bytes32 data) external {
         _writeDelegation(location, position, data);
     }
 
-    function exposedWriteDelegation(bytes32 location, StoragePositions position, uint256 data) external {
+    function exposedWriteDelegation(bytes32 location, RegistryStorage.Positions position, uint256 data) external {
         _writeDelegation(location, position, data);
     }
 
-    function exposedWriteDelegationAddresses(bytes32 location, StoragePositions firstPacked, StoragePositions secondPacked, address from, address to, address contract_)
-        external
-    {
+    function exposedWriteDelegationAddresses(
+        bytes32 location,
+        RegistryStorage.Positions firstPacked,
+        RegistryStorage.Positions secondPacked,
+        address from,
+        address to,
+        address contract_
+    ) external {
         _writeDelegationAddresses(location, firstPacked, secondPacked, from, to, contract_);
     }
 
@@ -61,19 +68,19 @@ contract RegistryHarness is DelegateRegistry {
         delete temporaryStorage;
     }
 
-    function exposedLoadDelegationBytes32(bytes32 location, StoragePositions position) external view returns (bytes32 data) {
+    function exposedLoadDelegationBytes32(bytes32 location, RegistryStorage.Positions position) external view returns (bytes32 data) {
         return _loadDelegationBytes32(location, position);
     }
 
-    function exposedLoadDelegationUint(bytes32 location, StoragePositions position) external view returns (uint256 data) {
+    function exposedLoadDelegationUint(bytes32 location, RegistryStorage.Positions position) external view returns (uint256 data) {
         return _loadDelegationUint(location, position);
     }
 
-    function exposedLoadFrom(bytes32 location, StoragePositions firstPacked) external view returns (address from) {
+    function exposedLoadFrom(bytes32 location, RegistryStorage.Positions firstPacked) external view returns (address from) {
         return _loadFrom(location, firstPacked);
     }
 
-    function exposedLoadDelegationAddresses(bytes32 location, StoragePositions firstPacked, StoragePositions secondPacked)
+    function exposedLoadDelegationAddresses(bytes32 location, RegistryStorage.Positions firstPacked, RegistryStorage.Positions secondPacked)
         external
         view
         returns (address from, address to, address contract_)

--- a/test/RegistryUnitTests.t.sol
+++ b/test/RegistryUnitTests.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {console2} from "forge-std/console2.sol";
 import {IDelegateRegistry as IRegistry} from "src/IDelegateRegistry.sol";
 import {DelegateRegistry as Registry} from "src/DelegateRegistry.sol";
+import {RegistryStorage as Storage} from "src/libraries/RegistryStorage.sol";
 import {RegistryHashes as Hashes} from "src/libraries/RegistryHashes.sol";
 import {RegistryHarness as Harness} from "src/tools/RegistryHarness.sol";
 
@@ -337,15 +338,15 @@ contract RegistryUnitTests is Test {
     }
 
     function _checkStorage(uint256 amount, address contract_, address delegate, bytes32 hash, bytes32 rights, uint256 tokenId, address vault) internal {
-        assertEq(harness.exposedDelegations(hash).length, uint256(type(IRegistry.StoragePositions).max) + 1);
-        assertEq(address(uint160(uint256(harness.exposedDelegations(hash)[uint256(IRegistry.StoragePositions.secondPacked)]))), delegate);
-        assertEq(address(uint160(uint256(harness.exposedDelegations(hash)[uint256(IRegistry.StoragePositions.firstPacked)]))), vault);
-        assertEq(harness.exposedDelegations(hash)[uint256(IRegistry.StoragePositions.rights)], rights);
-        assertEq(uint256(harness.exposedDelegations(hash)[uint256(IRegistry.StoragePositions.tokenId)]), tokenId);
-        assertEq(uint256(harness.exposedDelegations(hash)[uint256(IRegistry.StoragePositions.amount)]), amount);
+        assertEq(harness.exposedDelegations(hash).length, uint256(type(Storage.Positions).max) + 1);
+        assertEq(address(uint160(uint256(harness.exposedDelegations(hash)[uint256(Storage.Positions.secondPacked)]))), delegate);
+        assertEq(address(uint160(uint256(harness.exposedDelegations(hash)[uint256(Storage.Positions.firstPacked)]))), vault);
+        assertEq(harness.exposedDelegations(hash)[uint256(Storage.Positions.rights)], rights);
+        assertEq(uint256(harness.exposedDelegations(hash)[uint256(Storage.Positions.tokenId)]), tokenId);
+        assertEq(uint256(harness.exposedDelegations(hash)[uint256(Storage.Positions.amount)]), amount);
         // Check token contract
-        uint256 contractFirst8Bytes = ((uint256(harness.exposedDelegations(hash)[uint256(IRegistry.StoragePositions.firstPacked)]) >> 160) << 96);
-        uint256 contractLast12Bytes = (uint256(harness.exposedDelegations(hash)[uint256(IRegistry.StoragePositions.secondPacked)]) >> 160);
+        uint256 contractFirst8Bytes = ((uint256(harness.exposedDelegations(hash)[uint256(Storage.Positions.firstPacked)]) >> 160) << 96);
+        uint256 contractLast12Bytes = (uint256(harness.exposedDelegations(hash)[uint256(Storage.Positions.secondPacked)]) >> 160);
         address decodedContract = address(uint160(contractFirst8Bytes | contractLast12Bytes));
         assertEq(decodedContract, contract_);
     }
@@ -723,8 +724,8 @@ contract RegistryUnitTests is Test {
     }
 
     function testWriteDelegationBytes32(bytes32 location, bytes32 notLocation, bytes32 data) public {
-        harness.exposedWriteDelegation(location, IRegistry.StoragePositions.firstPacked, data);
-        bytes32 formattedLocation = bytes32(uint256(location) + uint256(IRegistry.StoragePositions.firstPacked));
+        harness.exposedWriteDelegation(location, Storage.Positions.firstPacked, data);
+        bytes32 formattedLocation = bytes32(uint256(location) + uint256(Storage.Positions.firstPacked));
         bytes32 slotContains = harness.readSlot(formattedLocation);
         assertEq(slotContains, data);
         bytes32 notSlotContains = harness.readSlot(notLocation);
@@ -733,8 +734,8 @@ contract RegistryUnitTests is Test {
     }
 
     function testWriteDelegationUint256(bytes32 location, bytes32 notLocation, uint256 data) public {
-        harness.exposedWriteDelegation(location, IRegistry.StoragePositions.firstPacked, data);
-        bytes32 formattedLocation = bytes32(uint256(location) + uint256(IRegistry.StoragePositions.firstPacked));
+        harness.exposedWriteDelegation(location, Storage.Positions.firstPacked, data);
+        bytes32 formattedLocation = bytes32(uint256(location) + uint256(Storage.Positions.firstPacked));
         uint256 slotContains = uint256(harness.readSlot(formattedLocation));
         assertEq(slotContains, data);
         uint256 notSlotContains = uint256(harness.readSlot(notLocation));
@@ -745,12 +746,12 @@ contract RegistryUnitTests is Test {
     // @dev see IDelegateRegistry for packed layout
     function testWriteDelegationAddresses(bytes32 location, address from, address to, address contract_) public {
         vm.assume(uint256(location) < type(uint256).max - 10); // Prevents overflow
-        harness.exposedWriteDelegationAddresses(location, IRegistry.StoragePositions.firstPacked, IRegistry.StoragePositions.secondPacked, from, to, contract_);
+        harness.exposedWriteDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, from, to, contract_);
         uint256 contractUint256 = uint256(uint160(contract_));
         uint256 first8BytesContract = (contractUint256 >> 96);
         uint256 last12BytesContract = ((contractUint256 << 160) >> 160);
-        bytes32 formattedLocation1 = bytes32(uint256(location) + uint256(IRegistry.StoragePositions.firstPacked));
-        bytes32 formattedLocation2 = bytes32(uint256(location) + uint256(IRegistry.StoragePositions.secondPacked));
+        bytes32 formattedLocation1 = bytes32(uint256(location) + uint256(Storage.Positions.firstPacked));
+        bytes32 formattedLocation2 = bytes32(uint256(location) + uint256(Storage.Positions.secondPacked));
         bytes32 slot1 = harness.readSlot(formattedLocation1);
         bytes32 slot2 = harness.readSlot(formattedLocation2);
         // Checking from, to, contract_ here
@@ -763,34 +764,34 @@ contract RegistryUnitTests is Test {
     /// TODO: enumeration helper functions
 
     function testLoadDelegationBytes32(bytes32 location, bytes32 data) public {
-        bytes32 formattedLocation = bytes32(uint256(location) + uint256(IRegistry.StoragePositions.firstPacked));
+        bytes32 formattedLocation = bytes32(uint256(location) + uint256(Storage.Positions.firstPacked));
         vm.store(address(harness), formattedLocation, data);
-        assertEq(data, harness.exposedLoadDelegationBytes32(location, IRegistry.StoragePositions.firstPacked));
+        assertEq(data, harness.exposedLoadDelegationBytes32(location, Storage.Positions.firstPacked));
     }
 
     function testLoadDelegationUint256(bytes32 location, uint256 data) public {
-        bytes32 formattedLocation = bytes32(uint256(location) + uint256(IRegistry.StoragePositions.firstPacked));
+        bytes32 formattedLocation = bytes32(uint256(location) + uint256(Storage.Positions.firstPacked));
         vm.store(address(harness), formattedLocation, bytes32(data));
-        assertEq(data, harness.exposedLoadDelegationUint(location, IRegistry.StoragePositions.firstPacked));
+        assertEq(data, harness.exposedLoadDelegationUint(location, Storage.Positions.firstPacked));
     }
 
     function testLoadFrom(bytes32 location, uint256 from) public {
-        bytes32 formattedLocation = bytes32(uint256(location) + uint256(IRegistry.StoragePositions.firstPacked));
+        bytes32 formattedLocation = bytes32(uint256(location) + uint256(Storage.Positions.firstPacked));
         vm.store(address(harness), formattedLocation, bytes32(from));
-        assertEq(address(uint160(((from << 96) >> 96))), harness.exposedLoadFrom(location, IRegistry.StoragePositions.firstPacked));
+        assertEq(address(uint160(((from << 96) >> 96))), harness.exposedLoadFrom(location, Storage.Positions.firstPacked));
     }
 
     function testLoadDelegationAddresses(bytes32 location, address from, address to, address contract_) public {
-        harness.exposedWriteDelegationAddresses(location, IRegistry.StoragePositions.firstPacked, IRegistry.StoragePositions.secondPacked, from, to, contract_);
+        harness.exposedWriteDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked, from, to, contract_);
         (address checkFrom, address checkTo, address checkContract) =
-            harness.exposedLoadDelegationAddresses(location, IRegistry.StoragePositions.firstPacked, IRegistry.StoragePositions.secondPacked);
+            harness.exposedLoadDelegationAddresses(location, Storage.Positions.firstPacked, Storage.Positions.secondPacked);
         assertEq(from, checkFrom);
         assertEq(to, checkTo);
         assertEq(contract_, checkContract);
     }
 
     function testValidateDelegation(bytes32 location, address from, bytes32 notLocation, address notFrom) public {
-        bytes32 formattedLocation = bytes32(uint256(location) + uint256(IRegistry.StoragePositions.firstPacked));
+        bytes32 formattedLocation = bytes32(uint256(location) + uint256(Storage.Positions.firstPacked));
         vm.store(address(harness), formattedLocation, bytes32(uint256(uint160(from))));
         vm.assume(formattedLocation != notLocation);
         vm.assume(from != notFrom);


### PR DESCRIPTION
### `RegistryStorage` library ###

Moved the struct for storage positions here. Also contains methods for decoding / encoding the data for the packed address storage. Additional `unpackAddress` method for decoding `from` or `to` from their packed slot.

### Reduced visual complexity of registry ###

Reduced visual complexity of registry by importing `RegistryHashes` as `Hashes` and `RegistryStorage` as `Storage`.